### PR TITLE
Feat/post launch feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ xcuserdata/
 *.generated.plist
 DerivedData/
 build/
+.local

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -259,6 +259,7 @@ struct ContentView: View {
         let previous = CredentialStore.load()
         CredentialStore.save(baseURL: baseURL, apiKey: apiKey)
         VisibleSections.save(visibleSections)
+        chunking = chunking.clampedToValidSize()
         ChunkingSettings.save(chunking)
         let credentialsChanged = previous?.apiKey != apiKey || previous?.baseURL.absoluteString != baseURL
         do {

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -1,11 +1,14 @@
 import SwiftUI
-import AppKit
 
 struct ContentView: View {
     @State private var baseURL = ""
     @State private var apiKey = ""
     @State private var showKey = false
     @State private var visibleSections: Set<SectionKind> = Set(SectionKind.allCases)
+    @State private var chunking = ChunkingSettings.default
+    @State private var isFreeingSpace = false
+    @State private var freedMessage: String?
+    @State private var selectedTab: AppTab = .setup
     @State private var status: Status = .idle
     @State private var isWorking = false
     @State private var isEnabled = false
@@ -19,13 +22,31 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            Divider()
-            form
+            TabStrip(selection: $selectedTab)
+            Group {
+                switch selectedTab {
+                case .setup:
+                    form
+                case .options:
+                    optionsTab
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             Divider()
             footer
         }
         .frame(width: 480, height: 640)
         .task { await loadState() }
+    }
+
+    private var optionsTab: some View {
+        OptionsTab(
+            chunking: $chunking,
+            isEnabled: isEnabled,
+            isFreeingSpace: isFreeingSpace,
+            freedMessage: freedMessage,
+            onFreeUpSpace: { Task { await freeUpSpace() } }
+        )
     }
 
     // MARK: - Header
@@ -93,16 +114,6 @@ struct ContentView: View {
                         }
                         .textFieldStyle(.plain)
                         .autocorrectionDisabled()
-
-                        Button {
-                            guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
-                            apiKey = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
-                        } label: {
-                            Image(systemName: "doc.on.clipboard")
-                        }
-                        .buttonStyle(.borderless)
-                        .foregroundStyle(.secondary)
-                        .help("Paste API key")
 
                         let keyIcon: String = if showKey { "eye.slash.fill" } else { "eye.fill" }
                         let keyHelp: String = if showKey { "Hide key" } else { "Show key" }
@@ -225,6 +236,7 @@ struct ContentView: View {
             apiKey = credentials.apiKey
         }
         visibleSections = VisibleSections.load()
+        chunking = ChunkingSettings.load()
         isEnabled = await DomainManager.isRegistered()
     }
 
@@ -247,6 +259,7 @@ struct ContentView: View {
         let previous = CredentialStore.load()
         CredentialStore.save(baseURL: baseURL, apiKey: apiKey)
         VisibleSections.save(visibleSections)
+        ChunkingSettings.save(chunking)
         let credentialsChanged = previous?.apiKey != apiKey || previous?.baseURL.absoluteString != baseURL
         do {
             if isEnabled && credentialsChanged {
@@ -273,5 +286,12 @@ struct ContentView: View {
         } catch {
             status = .failure("Couldn’t remove the Finder location.")
         }
+    }
+
+    private func freeUpSpace() async {
+        isFreeingSpace = true
+        defer { isFreeingSpace = false }
+        let count = await SpaceManager.freeUpSpace()
+        freedMessage = "Reverted \(count) downloaded files to placeholders."
     }
 }

--- a/App/OptionsTab.swift
+++ b/App/OptionsTab.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+// The "Options" tab: how very large folders are presented, and reclaiming the
+// disk that downloaded originals take. Bindings are owned by ContentView so the
+// values save alongside the rest of the settings when the domain is enabled.
+struct OptionsTab: View {
+    @Binding var chunking: ChunkingSettings
+    let isEnabled: Bool
+    let isFreeingSpace: Bool
+    let freedMessage: String?
+    let onFreeUpSpace: () -> Void
+
+    var body: some View {
+        Form {
+            largeFolders
+            storage
+        }
+        .formStyle(.grouped)
+    }
+
+    private var largeFolders: some View {
+        Section {
+            Toggle(isOn: $chunking.enabled) {
+                Label("Split large folders", systemImage: "square.grid.2x2")
+            }
+            if chunking.enabled {
+                Picker(selection: $chunking.strategy) {
+                    Text("Pages").tag(ChunkStrategy.pages)
+                    Text("Year & month").tag(ChunkStrategy.date)
+                } label: {
+                    Label("Group by", systemImage: "calendar")
+                }
+                LabeledContent("Photos per page") {
+                    HStack(spacing: 4) {
+                        TextField("", value: $chunking.size, format: .number)
+                            .textFieldStyle(.roundedBorder)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: 72)
+                        Stepper("", value: $chunking.size, in: 100...10000, step: 100)
+                            .labelsHidden()
+                    }
+                }
+            }
+        } header: {
+            Text("Large folders")
+        } footer: {
+            Text("Folders larger than this many photos are split so each part loads on its own. “Pages” makes numbered slices; “Year & month” groups by date and pages a month only if it is itself too big. Places use pages. Takes effect on the next Update.")
+        }
+    }
+
+    private var storage: some View {
+        Section {
+            Button {
+                onFreeUpSpace()
+            } label: {
+                HStack(spacing: 6) {
+                    if isFreeingSpace {
+                        ProgressView().controlSize(.small)
+                    }
+                    Text("Free up space")
+                }
+            }
+            .disabled(isFreeingSpace || isEnabled == false)
+
+            if let freedMessage {
+                Text(freedMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Storage")
+        } footer: {
+            Text("Reverts downloaded originals to placeholders to reclaim disk. They re-download when next opened. Files you have open are kept.")
+        }
+        .listRowBackground(Color.clear)
+    }
+}

--- a/App/OptionsTab.swift
+++ b/App/OptionsTab.swift
@@ -36,7 +36,7 @@ struct OptionsTab: View {
                             .textFieldStyle(.roundedBorder)
                             .multilineTextAlignment(.trailing)
                             .frame(width: 72)
-                        Stepper("", value: $chunking.size, in: 100...10000, step: 100)
+                        Stepper("", value: $chunking.size, in: ChunkingSettings.sizeRange, step: 100)
                             .labelsHidden()
                     }
                 }

--- a/App/README.md
+++ b/App/README.md
@@ -1,8 +1,11 @@
 # App
 
-The container app (`ImmichDrive`). It does two things: collect your Immich server URL and API key, and register the File Provider domain so "Findich" shows up in the Finder sidebar. It does not browse files itself; the [extension](../FileProvider) handles all of that.
+The container app (`ImmichDrive`). It collects your Immich server URL and API key, registers the File Provider domain so "Findich" shows up in the Finder sidebar, and exposes options for how large folders appear and for reclaiming downloaded-file disk. It does not browse files itself; the [extension](../FileProvider) handles all of that.
 
-- `ContentView.swift`: the SwiftUI config window, with the server URL and API key fields, the section toggles, and the Connect & Enable / Disable buttons.
+- `ContentView.swift`: the SwiftUI config window. A Setup tab (server URL and API key fields, the section toggles, and the Connect & Enable / Disable buttons) and an Options tab.
+- `TabStrip.swift`: the Finder-style Setup / Options tab strip.
+- `OptionsTab.swift`: the Options tab. Controls how large folders split (Pages or Year & month, and the page size) and the Free up space action.
+- `SpaceManager.swift`: drives Free up space. Enumerates the materialized items and reverts the downloaded originals back to placeholders via `NSFileProviderManager.evictItem`; files in use are skipped.
 - `DomainManager.swift`: adds, removes, and reloads the File Provider domain, and signals the Finder to refresh. Reloading on a credential change is what lets a new API key take effect.
 - `ImmichDriveApp.swift`: the app entry point.
 - `App.entitlements`: App Group plus sandbox, required for a File Provider container.

--- a/App/SpaceManager.swift
+++ b/App/SpaceManager.swift
@@ -1,0 +1,107 @@
+import Foundation
+import FileProvider
+
+// Drives "Free up space": reverts downloaded originals to placeholders so they
+// stop taking disk. Lives in the App target next to DomainManager, which already
+// owns the NSFileProviderManager(for:) pattern. The system refuses to evict files
+// that are open or have unsynced edits, so per-item failures are skipped.
+enum SpaceManager {
+    private static var domain: NSFileProviderDomain {
+        NSFileProviderDomain(
+            identifier: NSFileProviderDomainIdentifier(rawValue: AppGroup.domainIdentifier),
+            displayName: AppGroup.domainDisplayName
+        )
+    }
+
+    static func freeUpSpace() async -> Int {
+        guard let manager = NSFileProviderManager(for: domain) else {
+            return 0
+        }
+        let identifiers = await materializedAssetIdentifiers(manager: manager)
+        var evicted = 0
+        for identifier in identifiers {
+            let didEvict = await evict(identifier, manager: manager)
+            if didEvict {
+                evicted += 1
+            }
+        }
+        fileProviderLog.log("freeUpSpace evicted \(evicted, privacy: .public) of \(identifiers.count, privacy: .public) candidates")
+        return evicted
+    }
+
+    private static func materializedAssetIdentifiers(manager: NSFileProviderManager) async -> [NSFileProviderItemIdentifier] {
+        let items = await enumerateMaterialized(manager: manager)
+        return items.compactMap { item in
+            guard isAssetIdentifier(item.itemIdentifier.rawValue) else {
+                return nil
+            }
+            return item.itemIdentifier
+        }
+    }
+
+    // Asset identifier prefixes, mirroring the ItemID grammar in the extension
+    // target (which the app cannot import). Folders never materialize, so this is
+    // a guard against ever evicting a container identifier by mistake.
+    private static func isAssetIdentifier(_ raw: String) -> Bool {
+        let prefixes = ["asset:", "tasset:", "passet:", "qasset:", "tagasset:", "fasset:"]
+        return prefixes.contains { raw.hasPrefix($0) }
+    }
+
+    // Drives the materialized-items enumerator manually: the starting page is
+    // Data() per the SDK, the app plays the observer role, and the observer pages
+    // to the end before calling back once with everything on disk.
+    private static func enumerateMaterialized(manager: NSFileProviderManager) async -> [NSFileProviderItem] {
+        let enumerator = manager.enumeratorForMaterializedItems()
+        return await withCheckedContinuation { continuation in
+            let observer = MaterializedObserver(enumerator: enumerator) { items in
+                enumerator.invalidate()
+                continuation.resume(returning: items)
+            }
+            enumerator.enumerateItems(for: observer, startingAt: NSFileProviderPage(Data()))
+        }
+    }
+
+    private static func evict(_ identifier: NSFileProviderItemIdentifier, manager: NSFileProviderManager) async -> Bool {
+        await withCheckedContinuation { continuation in
+            manager.evictItem(identifier: identifier) { error in
+                if let error {
+                    fileProviderLog.error("evict failed for \(identifier.rawValue, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    continuation.resume(returning: false)
+                    return
+                }
+                continuation.resume(returning: true)
+            }
+        }
+    }
+}
+
+// Accumulates the materialized items across pages, then reports them once the
+// enumeration finishes (upTo nil). On error it reports whatever it gathered so a
+// partial enumeration still frees what it found.
+final class MaterializedObserver: NSObject, NSFileProviderEnumerationObserver {
+    private var items: [NSFileProviderItem] = []
+    private let enumerator: NSFileProviderEnumerator
+    private let completion: ([NSFileProviderItem]) -> Void
+
+    init(enumerator: NSFileProviderEnumerator, completion: @escaping ([NSFileProviderItem]) -> Void) {
+        self.enumerator = enumerator
+        self.completion = completion
+    }
+
+    func didEnumerate(_ updatedItems: [any NSFileProviderItemProtocol]) {
+        items.append(contentsOf: updatedItems)
+    }
+
+    func finishEnumerating(upTo nextPage: NSFileProviderPage?) {
+        if let nextPage {
+            enumerator.enumerateItems(for: self, startingAt: nextPage)
+            return
+        }
+        completion(items)
+    }
+
+    func finishEnumeratingWithError(_ error: any Error) {
+        fileProviderLog.error("materialized enumeration error: \(error.localizedDescription, privacy: .public)")
+        completion(items)
+    }
+}

--- a/App/TabStrip.swift
+++ b/App/TabStrip.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+enum AppTab: Hashable {
+    case setup
+    case options
+}
+
+// A Finder-style tab strip: equal-width tabs aligned to the form content, the
+// active one a grey rounded chip. The tabs are not focusable so the window does
+// not open with a focus ring on a tab.
+struct TabStrip: View {
+    @Binding var selection: AppTab
+
+    var body: some View {
+        HStack(spacing: 4) {
+            tabButton(.setup, title: "Setup")
+            tabButton(.options, title: "Options")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity)
+    }
+
+    private func tabButton(_ tab: AppTab, title: String) -> some View {
+        let isSelected = selection == tab
+        let weight: Font.Weight = if isSelected { .semibold } else { .regular }
+        let textColor: Color = if isSelected { .primary } else { .secondary }
+        let fillOpacity: Double = if isSelected { 0.1 } else { 0.04 }
+        return Button {
+            selection = tab
+        } label: {
+            Text(title)
+                .font(.subheadline.weight(weight))
+                .foregroundStyle(textColor)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 5)
+                .background {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.primary.opacity(fillOpacity))
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+    }
+}

--- a/FileProvider/FileProviderExtension.swift
+++ b/FileProvider/FileProviderExtension.swift
@@ -24,6 +24,15 @@ enum ItemID {
     case tagAsset(tagID: String, assetID: String)
     case favoritesSection
     case favoriteAsset(assetID: String)
+    // A synthetic sub-folder of a large asset container, holding one fixed-size
+    // slice of its assets. The location it slices is encoded inline so the chunk
+    // can both enumerate its page and report the right parent folder.
+    case chunk(location: AssetLocation, index: Int)
+    // The date strategy's folders: a year, a month, or one page of a large month.
+    // Each carries the location it groups so it can enumerate and parent itself.
+    case dateYear(location: AssetLocation, year: String)
+    case dateMonth(location: AssetLocation, yearMonth: String)
+    case datePage(location: AssetLocation, yearMonth: String, page: Int)
     case other
 
     init(_ identifier: NSFileProviderItemIdentifier) {
@@ -129,6 +138,37 @@ enum ItemID {
                 return
             }
         }
+        if raw.hasPrefix("chunk:") {
+            // index (digits, no colons) first, then the location code (which may
+            // itself contain colons for a place), so split only once.
+            let parts = raw.dropFirst("chunk:".count).split(separator: ":", maxSplits: 1).map(String.init)
+            if parts.count == 2, let index = Int(parts[0]), index >= 0, let location = AssetLocation(code: parts[1]) {
+                self = .chunk(location: location, index: index)
+                return
+            }
+        }
+        if raw.hasPrefix("dyear:") {
+            let parts = raw.dropFirst("dyear:".count).split(separator: ":", maxSplits: 1).map(String.init)
+            if parts.count == 2, let location = AssetLocation(code: parts[1]) {
+                self = .dateYear(location: location, year: parts[0])
+                return
+            }
+        }
+        if raw.hasPrefix("dmonth:") {
+            let parts = raw.dropFirst("dmonth:".count).split(separator: ":", maxSplits: 1).map(String.init)
+            if parts.count == 2, let location = AssetLocation(code: parts[1]) {
+                self = .dateMonth(location: location, yearMonth: parts[0])
+                return
+            }
+        }
+        if raw.hasPrefix("dpage:") {
+            // page (digits) then yearMonth ("YYYY-MM", no bare colon) then the code.
+            let parts = raw.dropFirst("dpage:".count).split(separator: ":", maxSplits: 2).map(String.init)
+            if parts.count == 3, let page = Int(parts[0]), page >= 0, let location = AssetLocation(code: parts[2]) {
+                self = .datePage(location: location, yearMonth: parts[1], page: page)
+                return
+            }
+        }
         self = .other
     }
 
@@ -198,6 +238,14 @@ enum ItemID {
             return NSFileProviderItemIdentifier(rawValue: "section:favorites")
         case .favoriteAsset(let assetID):
             return NSFileProviderItemIdentifier(rawValue: "fasset:\(assetID)")
+        case .chunk(let location, let index):
+            return NSFileProviderItemIdentifier(rawValue: "chunk:\(index):\(location.code)")
+        case .dateYear(let location, let year):
+            return NSFileProviderItemIdentifier(rawValue: "dyear:\(year):\(location.code)")
+        case .dateMonth(let location, let yearMonth):
+            return NSFileProviderItemIdentifier(rawValue: "dmonth:\(yearMonth):\(location.code)")
+        case .datePage(let location, let yearMonth, let page):
+            return NSFileProviderItemIdentifier(rawValue: "dpage:\(page):\(yearMonth):\(location.code)")
         case .other:
             return NSFileProviderItemIdentifier(rawValue: "")
         }
@@ -270,7 +318,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                         progress.completedUnitCount = 1
                         return
                     }
-                    completionHandler(ImmichItem(asset: resolved.asset, location: ref.location, filename: resolved.filename), nil)
+                    completionHandler(ImmichItem(asset: resolved.asset, location: ref.location, filename: resolved.filename, parent: resolved.parent), nil)
                 } catch {
                     completionHandler(nil, fileProviderError(from: error))
                 }
@@ -362,10 +410,51 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                 progress.completedUnitCount = 1
             }
             return progress
+        case .chunk(let location, let index):
+            guard let cache else {
+                completionHandler(nil, Self.error(.notAuthenticated))
+                return progress
+            }
+            Task {
+                do {
+                    let count = try await cache.assetCount(for: location)
+                    let settings = ChunkingSettings.load()
+                    completionHandler(ChunkFolderItem(location: location, index: index, size: settings.size, totalCount: count), nil)
+                } catch {
+                    completionHandler(nil, fileProviderError(from: error))
+                }
+                progress.completedUnitCount = 1
+            }
+            return progress
+        case .dateYear(let location, let year):
+            return dateFolder(.year(year), location: location, cache: cache, progress: progress, completionHandler: completionHandler)
+        case .dateMonth(let location, let yearMonth):
+            return dateFolder(.month(yearMonth), location: location, cache: cache, progress: progress, completionHandler: completionHandler)
+        case .datePage(let location, let yearMonth, let page):
+            return dateFolder(.page(month: yearMonth, index: page), location: location, cache: cache, progress: progress, completionHandler: completionHandler)
         case .asset, .timelineAsset, .personAsset, .placeAsset, .tagAsset, .favoriteAsset, .other:
             completionHandler(nil, Self.error(.noSuchItem))
         }
         progress.completedUnitCount = 1
+        return progress
+    }
+
+    // Shared body for the three date-folder item(for:) cases: builds the folder
+    // from the current layout, or reports notAuthenticated without a client.
+    private func dateFolder(_ node: DateChunkNode, location: AssetLocation, cache: ImmichCache?, progress: Progress, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
+        nonisolated(unsafe) let completionHandler = completionHandler
+        guard let cache else {
+            completionHandler(nil, Self.error(.notAuthenticated))
+            return progress
+        }
+        Task {
+            do {
+                completionHandler(try await Self.dateFolderItem(node, location: location, cache: cache), nil)
+            } catch {
+                completionHandler(nil, fileProviderError(from: error))
+            }
+            progress.completedUnitCount = 1
+        }
         return progress
     }
 
@@ -390,7 +479,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                 let data = try await client.downloadOriginal(assetID: ref.assetID)
                 fileProviderLog.log("fetchContents \(ref.assetID, privacy: .public): \(data.count, privacy: .public) bytes")
                 let url = try Self.writeTemporary(data: data, filename: resolved.filename)
-                completionHandler(url, ImmichItem(asset: resolved.asset, location: ref.location, filename: resolved.filename), nil)
+                completionHandler(url, ImmichItem(asset: resolved.asset, location: ref.location, filename: resolved.filename, parent: resolved.parent), nil)
             } catch {
                 fileProviderLog.error("fetchContents failed for \(ref.assetID, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 completionHandler(nil, nil, fileProviderError(from: error))
@@ -434,6 +523,14 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return ItemEnumerator(client: client, cache: cache, container: .tag(id: id))
         case .favoritesSection:
             return ItemEnumerator(client: client, cache: cache, container: .favorites)
+        case .chunk(let location, let index):
+            return ItemEnumerator(client: client, cache: cache, container: .chunk(location: location, index: index))
+        case .dateYear(let location, let year):
+            return ItemEnumerator(client: client, cache: cache, container: .dateYear(location: location, year: year))
+        case .dateMonth(let location, let yearMonth):
+            return ItemEnumerator(client: client, cache: cache, container: .dateMonth(location: location, yearMonth: yearMonth))
+        case .datePage(let location, let yearMonth, let page):
+            return ItemEnumerator(client: client, cache: cache, container: .datePage(location: location, yearMonth: yearMonth, page: page))
         case .asset, .timelineAsset, .personAsset, .placeAsset, .tagAsset, .favoriteAsset:
             throw Self.error(.noSuchItem)
         }
@@ -503,10 +600,11 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     progress.completedUnitCount = 1
                     return
                 }
-                completionHandler(ImmichItem(asset: resolved.asset, location: .album(id: albumID), filename: resolved.filename), [], false, nil)
+                let parent = await Self.assetParent(for: .album(id: albumID), asset: resolved.asset, in: siblings, cache: cache)
+                completionHandler(ImmichItem(asset: resolved.asset, location: .album(id: albumID), filename: resolved.filename, parent: parent), [], false, nil)
                 Self.signalChange(domain: domain, container: ItemID.album(albumID).identifier)
             } catch {
-                fileProviderLog.error("upload failed for \(filename, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                fileProviderLog.error("upload failed for \(filename, privacy: .private): \(error.localizedDescription, privacy: .public)")
                 completionHandler(nil, [], false, fileProviderError(from: error))
             }
             progress.completedUnitCount = 1
@@ -619,9 +717,57 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     // Static so the async Tasks below can call it without capturing self (a
     // non-Sendable NSObject), which Swift 6 region isolation forbids.
-    private static func resolve(_ ref: (assetID: String, location: AssetLocation), cache: ImmichCache) async throws -> (asset: Asset, filename: String)? {
+    private static func resolve(_ ref: (assetID: String, location: AssetLocation), cache: ImmichCache) async throws -> (asset: Asset, filename: String, parent: ItemID?)? {
         let siblings = try await ref.location.siblings(from: cache)
-        return resolveAsset(ref.assetID, in: siblings)
+        guard let resolved = resolveAsset(ref.assetID, in: siblings) else {
+            return nil
+        }
+        let parent = await assetParent(for: ref.location, asset: resolved.asset, in: siblings, cache: cache)
+        return (resolved.asset, resolved.filename, parent)
+    }
+
+    // The sub-folder an asset reports as its parent, or nil when its container is
+    // not chunked. The position comes from the same order:.asc membership
+    // enumeration pages over, so the parent reported here matches the folder that
+    // listed it. The count falls back to the fetched membership if the statistics
+    // call fails, so resolution never breaks just because the count is briefly
+    // unavailable.
+    private static func assetParent(for location: AssetLocation, asset: Asset, in siblings: [Asset], cache: ImmichCache) async -> ItemID? {
+        let settings = ChunkingSettings.load()
+        guard settings.enabled else {
+            return nil
+        }
+        if settings.strategy == .date, location.supportsDateChunking {
+            guard siblings.count > settings.size else {
+                return nil
+            }
+            let layout = DateChunkLayout(monthCounts: DateChunkLayout.counts(of: siblings), size: settings.size)
+            let month = DateChunkLayout.month(of: asset)
+            let monthAssets = siblings.filter { DateChunkLayout.month(of: $0) == month }
+            guard let indexInMonth = monthAssets.firstIndex(where: { $0.assetID == asset.assetID }),
+                  let node = layout.assetParentNode(month: month, indexInMonth: indexInMonth) else {
+                return nil
+            }
+            return dateNodeID(node, location: location)
+        }
+        guard let position = siblings.firstIndex(where: { $0.assetID == asset.assetID }) else {
+            return nil
+        }
+        let count = (try? await cache.assetCount(for: location)) ?? siblings.count
+        guard settings.isChunked(count: count) else {
+            return nil
+        }
+        return ItemID.chunk(location: location, index: settings.chunkIndex(forAssetIndex: position, count: count))
+    }
+
+    // Builds the folder item for a date node out of context: fetches the
+    // membership, rebuilds the same layout the enumerator used, and reports the
+    // node's identifier, parent, and name from it.
+    private static func dateFolderItem(_ node: DateChunkNode, location: AssetLocation, cache: ImmichCache) async throws -> NSFileProviderItem {
+        let size = ChunkingSettings.load().size
+        let siblings = try await cache.assets(for: location)
+        let layout = DateChunkLayout(monthCounts: DateChunkLayout.counts(of: siblings), size: size)
+        return FolderItem(id: dateNodeID(node, location: location), parent: dateParentID(of: node, location: location, layout: layout), filename: dateNodeName(node, layout: layout))
     }
 
     private static func error(_ code: NSFileProviderError.Code) -> NSError {
@@ -635,7 +781,11 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     private static func writeTemporary(data: Data, filename: String) throws -> URL {
         let safeName = filename.replacingOccurrences(of: "/", with: "_")
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString)-\(safeName)")
-        try data.write(to: url)
+        // Owner-only from creation: the decoded original is a private photo, so keep
+        // it out of reach of other same-user processes while it sits in the temp dir.
+        guard FileManager.default.createFile(atPath: url.path, contents: data, attributes: [.posixPermissions: 0o600]) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
         return url
     }
 

--- a/FileProvider/ImmichItem.swift
+++ b/FileProvider/ImmichItem.swift
@@ -52,6 +52,91 @@ extension AssetLocation {
         case .favorite:                     return "favorites"
         }
     }
+
+    // A compact, reversible encoding embedded inside a chunk folder's identifier
+    // (chunk:<index>:<code>), so a chunk knows which location it slices. Country
+    // is assumed colon-free (the same assumption the qasset identifier makes), so
+    // the city, last, may contain anything.
+    var code: String {
+        switch self {
+        case .album(let id):                return "a:\(id)"
+        case .month(let yearMonth):         return "m:\(yearMonth)"
+        case .person(let id):               return "p:\(id)"
+        case .place(let country, let city): return "c:\(country):\(city)"
+        case .tag(let id):                  return "t:\(id)"
+        case .favorite:                     return "f"
+        }
+    }
+
+    init?(code: String) {
+        if code == "f" {
+            self = .favorite
+            return
+        }
+        if code.hasPrefix("a:") {
+            self = .album(id: String(code.dropFirst(2)))
+            return
+        }
+        if code.hasPrefix("m:") {
+            self = .month(yearMonth: String(code.dropFirst(2)))
+            return
+        }
+        if code.hasPrefix("p:") {
+            self = .person(id: String(code.dropFirst(2)))
+            return
+        }
+        if code.hasPrefix("t:") {
+            self = .tag(id: String(code.dropFirst(2)))
+            return
+        }
+        if code.hasPrefix("c:") {
+            let parts = code.dropFirst(2).split(separator: ":", maxSplits: 1).map(String.init)
+            if parts.count == 2 {
+                self = .place(country: parts[0], city: parts[1])
+                return
+            }
+        }
+        return nil
+    }
+
+    // Whether the date strategy groups this location into year/month folders. The
+    // grouping comes from each asset's capture date in the fetched membership, so
+    // it could technically apply anywhere; it is deliberately left off for the
+    // Timeline months (a month is already the finest date unit) and for Places,
+    // which stay on page chunks. Albums, People, Tags, and Favorites get the tree.
+    var supportsDateChunking: Bool {
+        switch self {
+        case .album, .person, .tag, .favorite: return true
+        case .month, .place:                   return false
+        }
+    }
+
+    // The paged /search/metadata query backing this location, so the one-to-one
+    // location->search mapping lives here instead of being spelled out at every
+    // call site that needs a page.
+    var search: AssetSearch {
+        switch self {
+        case .album(let id):                return .album(id: id)
+        case .month(let yearMonth):         return .month(yearMonth: yearMonth)
+        case .person(let id):               return .person(id: id)
+        case .place(let country, let city): return .place(country: country, city: city)
+        case .tag(let id):                  return .tag(id: id)
+        case .favorite:                     return .favorite
+        }
+    }
+}
+
+// Month symbol names, computed once. Read-only and value-typed, so safe to share.
+private let monthSymbolNames: [String] = DateFormatter().standaloneMonthSymbols ?? []
+
+// "2024-03" -> "03 - March", falling back to the raw month number. Shared by the
+// Timeline month folders and the date strategy's month folders.
+func monthDisplayName(_ yearMonth: String) -> String {
+    let monthNumber = Int(yearMonth.suffix(2)) ?? 0
+    if monthNumber >= 1, monthNumber <= monthSymbolNames.count {
+        return String(format: "%02d - %@", monthNumber, monthSymbolNames[monthNumber - 1].capitalized)
+    }
+    return String(yearMonth.suffix(2))
 }
 
 func nameCounts(_ names: [String]) -> [String: Int] {
@@ -80,11 +165,13 @@ func disambiguatedName(base: String, id: String, counts: [String: Int]) -> Strin
 }
 
 // The single chokepoint that turns a container's asset list into items, so
-// enumeration and single-item resolution name files identically.
-func immichItems(from assets: [Asset], location: AssetLocation) -> [ImmichItem] {
+// enumeration and single-item resolution name files identically. When `parent` is
+// set, the items report that sub-folder as their parent instead of the container
+// itself (a page folder, or a date folder for the date strategy).
+func immichItems(from assets: [Asset], location: AssetLocation, parent: ItemID? = nil) -> [ImmichItem] {
     let counts = nameCounts(assets.map { $0.originalFileName })
     return assets.map {
-        ImmichItem(asset: $0, location: location, filename: disambiguatedName(base: $0.originalFileName, id: $0.assetID, counts: counts))
+        ImmichItem(asset: $0, location: location, filename: disambiguatedName(base: $0.originalFileName, id: $0.assetID, counts: counts), parent: parent)
     }
 }
 
@@ -101,19 +188,28 @@ final class ImmichItem: NSObject, NSFileProviderItem {
     private let asset: Asset
     private let location: AssetLocation
     private let displayName: String
+    private let parentOverride: ItemID?
 
-    init(asset: Asset, location: AssetLocation, filename: String) {
+    init(asset: Asset, location: AssetLocation, filename: String, parent: ItemID? = nil) {
         self.asset = asset
         self.location = location
         self.displayName = filename
+        self.parentOverride = parent
     }
 
     var itemIdentifier: NSFileProviderItemIdentifier {
         location.assetItemID(asset.assetID).identifier
     }
 
+    // When the asset lives in a chunked container its parent is the sub-folder it
+    // was enumerated under (a page folder, or a year/month folder for the date
+    // strategy); the asset's own identity is unchanged so every write path keeps
+    // resolving it the same way.
     var parentItemIdentifier: NSFileProviderItemIdentifier {
-        location.parentItemID.identifier
+        if let parentOverride {
+            return parentOverride.identifier
+        }
+        return location.parentItemID.identifier
     }
 
     var filename: String {
@@ -322,20 +418,80 @@ final class MonthItem: NSObject, NSFileProviderItem {
         ItemID.year(String(yearMonth.prefix(4))).identifier
     }
 
-    private static let monthNames: [String] = DateFormatter().standaloneMonthSymbols ?? []
-
     var filename: String {
-        let monthNumber = Int(yearMonth.suffix(2)) ?? 0
-        if monthNumber >= 1, monthNumber <= MonthItem.monthNames.count {
-            return String(format: "%02d - %@", monthNumber, MonthItem.monthNames[monthNumber - 1].capitalized)
-        }
-        return String(yearMonth.suffix(2))
+        monthDisplayName(yearMonth)
     }
 
     var contentType: UTType { .folder }
     var capabilities: NSFileProviderItemCapabilities { [.allowsContentEnumerating, .allowsReading] }
     var itemVersion: NSFileProviderItemVersion {
         let version = Data("month:\(yearMonth):named".utf8)
+        return NSFileProviderItemVersion(contentVersion: version, metadataVersion: version)
+    }
+}
+
+// Overflow-safe 0-based half-open slice bounds for page `index` of `total` items
+// at `size` per page. `index` can arrive from a crafted or stale identifier, so it
+// is clamped into the valid page range before any multiplication (the multiply
+// would otherwise trap on a huge index, before any later min could bound it).
+func chunkSlice(index: Int, size: Int, total: Int) -> Range<Int> {
+    let bounded = max(0, total)
+    guard size > 0 else {
+        return 0..<0
+    }
+    let pages = max(0, bounded - 1) / size + 1
+    let clampedIndex = min(max(0, index), pages - 1)
+    let start = clampedIndex * size
+    let end = min(start + size, bounded)
+    return start..<end
+}
+
+// Zero-padded "first-last" label for page `index` of `total` items at `size` per
+// page, so the page folders sort in order in Finder. Shared by the flat page
+// folders and the date strategy's per-month page folders.
+func chunkRangeLabel(index: Int, size: Int, total: Int) -> String {
+    let slice = chunkSlice(index: index, size: size, total: total)
+    let width = String(max(0, total)).count
+    return String(format: "%0\(width)d-%0\(width)d", slice.lowerBound + 1, slice.upperBound)
+}
+
+// One slice of a large asset container, shown as a sub-folder. Its name is a
+// zero-padded "first-last" range so the folders sort in order in Finder, and its
+// parent is the container the slice belongs to (album, month, person, ...).
+final class ChunkFolderItem: NSObject, NSFileProviderItem {
+    private let location: AssetLocation
+    private let index: Int
+    private let size: Int
+    private let totalCount: Int
+
+    init(location: AssetLocation, index: Int, size: Int, totalCount: Int) {
+        self.location = location
+        self.index = index
+        self.size = size
+        self.totalCount = totalCount
+    }
+
+    var itemIdentifier: NSFileProviderItemIdentifier {
+        ItemID.chunk(location: location, index: index).identifier
+    }
+
+    var parentItemIdentifier: NSFileProviderItemIdentifier {
+        location.parentItemID.identifier
+    }
+
+    var filename: String {
+        chunkRangeLabel(index: index, size: size, total: totalCount)
+    }
+
+    var contentType: UTType { .folder }
+    var capabilities: NSFileProviderItemCapabilities { [.allowsContentEnumerating, .allowsReading] }
+
+    var childItemCount: NSNumber? {
+        NSNumber(value: chunkSlice(index: index, size: size, total: totalCount).count)
+    }
+
+    var itemVersion: NSFileProviderItemVersion {
+        let version = Data("chunk:\(location.code):\(index):\(totalCount)".utf8)
         return NSFileProviderItemVersion(contentVersion: version, metadataVersion: version)
     }
 }

--- a/FileProvider/ItemEnumerator.swift
+++ b/FileProvider/ItemEnumerator.swift
@@ -11,6 +11,7 @@ actor ImmichCache {
     private var cityListTask: Task<[PlaceSummary], Error>?
     private var tagListTask: Task<[TagSummary], Error>?
     private var assetTasks: [String: Task<[Asset], Error>] = [:]
+    private var assetCountTasks: [String: Task<Int, Error>] = [:]
     private var timelineYearsTask: Task<[Int], Error>?
     private var timelineMonthsTasks: [String: Task<[String], Never>] = [:]
 
@@ -48,19 +49,43 @@ actor ImmichCache {
         }
     }
 
-    // One fetch path for every asset container; the location decides both the
-    // cache key and which server query backs it.
+    // Fetches and memoizes the full membership of an asset container. Backs
+    // single-asset resolution (item lookup, fetchContents); enumeration paginates
+    // separately so it never holds the whole folder at once.
     func assets(for location: AssetLocation) async throws -> [Asset] {
+        let key = location.cacheKey
+        if let existing = assetTasks[key] {
+            return try await existing.value
+        }
         let client = self.client
-        return try await cachedAssets(key: location.cacheKey) {
-            switch location {
-            case .album(let id):                return try await client.searchAllAlbum(albumID: id)
-            case .month(let yearMonth):         return try await client.searchAllMonth(yearMonth: yearMonth)
-            case .person(let id):               return try await client.searchAllPerson(personID: id)
-            case .place(let country, let city): return try await client.searchAllCity(country: country, city: city)
-            case .tag(let id):                  return try await client.searchAllTag(tagID: id)
-            case .favorite:                     return try await client.searchAllFavorites()
-            }
+        let search = location.search
+        let task = Task { try await client.searchAllViaPage(for: search, size: 1000) }
+        assetTasks[key] = task
+        do {
+            return try await task.value
+        } catch {
+            assetTasks[key] = nil
+            throw error
+        }
+    }
+
+    // Total asset count for a container, memoized like the asset lists. Backs the
+    // chunk-folder split: cheap (one /search/statistics call) so opening a large
+    // folder can list its chunk sub-folders without fetching every asset.
+    func assetCount(for location: AssetLocation) async throws -> Int {
+        let key = location.cacheKey
+        if let existing = assetCountTasks[key] {
+            return try await existing.value
+        }
+        let client = self.client
+        let search = location.search
+        let task = Task { try await client.searchStatistics(for: search) }
+        assetCountTasks[key] = task
+        do {
+            return try await task.value
+        } catch {
+            assetCountTasks[key] = nil
+            throw error
         }
     }
 
@@ -131,25 +156,12 @@ actor ImmichCache {
 
     func invalidate(_ location: AssetLocation) {
         assetTasks[location.cacheKey] = nil
+        assetCountTasks[location.cacheKey] = nil
     }
 
     func invalidateTimeline() {
         timelineYearsTask = nil
         timelineMonthsTasks = [:]
-    }
-
-    private func cachedAssets(key: String, fetch: @Sendable @escaping () async throws -> [Asset]) async throws -> [Asset] {
-        if let existing = assetTasks[key] {
-            return try await existing.value
-        }
-        let task = Task { try await fetch() }
-        assetTasks[key] = task
-        do {
-            return try await task.value
-        } catch {
-            assetTasks[key] = nil
-            throw error
-        }
     }
 }
 
@@ -189,6 +201,149 @@ enum EnumeratedContainer {
     case tags
     case tag(id: String)
     case favorites
+    case chunk(location: AssetLocation, index: Int)
+    case dateYear(location: AssetLocation, year: String)
+    case dateMonth(location: AssetLocation, yearMonth: String)
+    case datePage(location: AssetLocation, yearMonth: String, page: Int)
+}
+
+// Decodes the 1-based page number from a File Provider page cursor. The two
+// system sentinels and an empty cursor both mean the first page.
+func immichPageNumber(from page: NSFileProviderPage) -> Int {
+    let raw = page.rawValue
+    let isInitial = raw == NSFileProviderPage.initialPageSortedByName as Data
+        || raw == NSFileProviderPage.initialPageSortedByDate as Data
+    if isInitial || raw.isEmpty {
+        return 1
+    }
+    return Int(String(decoding: raw, as: UTF8.self)) ?? 1
+}
+
+// Fetches one /search/metadata page for a container and hands it to the observer,
+// finishing with the next page cursor while pages remain. The system re-enters
+// enumerateItems with that cursor, so the extension only ever holds one page,
+// which keeps memory bounded even for very large folders. A free function so the
+// enclosing Task never captures the non-Sendable ItemEnumerator.
+func enumerateAssetPage(_ location: AssetLocation, client: ImmichClient, page: NSFileProviderPage, observer: NSFileProviderEnumerationObserver) async throws {
+    let pageNumber = immichPageNumber(from: page)
+    let result = try await client.searchPage(for: location.search, page: pageNumber, size: 1000)
+    observer.didEnumerate(immichItems(from: result.assets, location: location))
+    if result.hasMore {
+        observer.finishEnumerating(upTo: NSFileProviderPage(Data(String(pageNumber + 1).utf8)))
+    } else {
+        observer.finishEnumerating(upTo: nil)
+    }
+}
+
+// Enumerates an asset container under the active chunking strategy. The date
+// strategy (for locations that support it) groups by year/month; otherwise the
+// page strategy splits into fixed-size slices when over the size; otherwise the
+// assets page directly. Listing page chunks needs only the count; the date
+// strategy needs the full membership, which it reuses for grouping and slicing.
+func enumerateAssetContainer(_ location: AssetLocation, cache: ImmichCache, client: ImmichClient, page: NSFileProviderPage, observer: NSFileProviderEnumerationObserver) async throws {
+    let settings = ChunkingSettings.load()
+    if settings.enabled, settings.strategy == .date, location.supportsDateChunking {
+        try await enumerateDateContainer(location, node: nil, cache: cache, observer: observer)
+        return
+    }
+    if settings.enabled {
+        let count = try await cache.assetCount(for: location)
+        if settings.isChunked(count: count) {
+            let chunks = settings.chunkCount(for: count)
+            fileProviderLog.log("chunking \(location.cacheKey, privacy: .public): \(count, privacy: .public) assets into \(chunks, privacy: .public) folders")
+            let items = (0..<chunks).map { ChunkFolderItem(location: location, index: $0, size: settings.size, totalCount: count) }
+            observer.didEnumerate(items)
+            observer.finishEnumerating(upTo: nil)
+            return
+        }
+    }
+    try await enumerateAssetPage(location, client: client, page: page, observer: observer)
+}
+
+// The ItemID and display name a layout node maps to for this location.
+func dateNodeID(_ node: DateChunkNode, location: AssetLocation) -> ItemID {
+    switch node {
+    case .year(let year):           return .dateYear(location: location, year: year)
+    case .month(let yearMonth):     return .dateMonth(location: location, yearMonth: yearMonth)
+    case .page(let yearMonth, let index): return .datePage(location: location, yearMonth: yearMonth, page: index)
+    }
+}
+
+// The ItemID a date node reports as its parent: its parent node, or the
+// container itself when that node sits at the top after collapsing.
+func dateParentID(of node: DateChunkNode, location: AssetLocation, layout: DateChunkLayout) -> ItemID {
+    guard let parent = layout.parentNode(of: node) else {
+        return location.parentItemID
+    }
+    return dateNodeID(parent, location: location)
+}
+
+func dateNodeName(_ node: DateChunkNode, layout: DateChunkLayout) -> String {
+    switch node {
+    case .year(let year):       return year
+    case .month(let yearMonth): return monthDisplayName(yearMonth)
+    case .page(let yearMonth, let index):
+        return chunkRangeLabel(index: index, size: layout.size, total: layout.count(month: yearMonth))
+    }
+}
+
+// Enumerates one node of the date tree (nil = the container itself). The whole
+// membership is fetched once and reused for both grouping and slicing, so every
+// level reads the same order:.asc list the resolver also sees.
+func enumerateDateContainer(_ location: AssetLocation, node: DateChunkNode?, cache: ImmichCache, observer: NSFileProviderEnumerationObserver) async throws {
+    let size = ChunkingSettings.load().size
+    let siblings = try await cache.assets(for: location)
+    let layout = DateChunkLayout(monthCounts: DateChunkLayout.counts(of: siblings), size: size)
+
+    // A page node is a leaf: deliver its month slice directly.
+    if case .page(let yearMonth, let index) = node {
+        let monthAssets = siblings.filter { DateChunkLayout.month(of: $0) == yearMonth }
+        let slice = Array(monthAssets[chunkSlice(index: index, size: size, total: monthAssets.count)])
+        observer.didEnumerate(immichItems(from: slice, location: location, parent: dateNodeID(.page(month: yearMonth, index: index), location: location)))
+        observer.finishEnumerating(upTo: nil)
+        return
+    }
+
+    // The container's own identifier, used as the parent of whatever it emits.
+    let containerID: ItemID
+    let children: DateChunkChildren
+    switch node {
+    case .year(let year):
+        containerID = .dateYear(location: location, year: year)
+        children = layout.yearChildren(year)
+    case .month(let yearMonth):
+        containerID = .dateMonth(location: location, yearMonth: yearMonth)
+        children = layout.monthChildren(yearMonth)
+    default:
+        containerID = location.parentItemID
+        if siblings.count <= size {
+            observer.didEnumerate(immichItems(from: siblings, location: location))
+            observer.finishEnumerating(upTo: nil)
+            return
+        }
+        children = layout.rootChildren()
+    }
+
+    switch children {
+    case .folders(let nodes):
+        fileProviderLog.log("date chunking \(location.cacheKey, privacy: .public): \(nodes.count, privacy: .public) folders under \(containerID.identifier.rawValue, privacy: .public)")
+        observer.didEnumerate(nodes.map { FolderItem(id: dateNodeID($0, location: location), parent: containerID, filename: dateNodeName($0, layout: layout)) })
+    case .assets(let yearMonth):
+        let monthAssets = siblings.filter { DateChunkLayout.month(of: $0) == yearMonth }
+        observer.didEnumerate(immichItems(from: monthAssets, location: location, parent: containerID))
+    }
+    observer.finishEnumerating(upTo: nil)
+}
+
+// Enumerates one chunk: a single /search/metadata page sized to the chunk size,
+// so the chunk holds exactly its slice. The page boundary matches the index math
+// the resolver uses (both over order:.asc), so an asset always lands in the chunk
+// folder that was listed for it.
+func enumerateChunkPage(_ location: AssetLocation, index: Int, client: ImmichClient, observer: NSFileProviderEnumerationObserver) async throws {
+    let size = ChunkingSettings.load().size
+    let result = try await client.searchPage(for: location.search, page: index + 1, size: size)
+    observer.didEnumerate(immichItems(from: result.assets, location: location, parent: ItemID.chunk(location: location, index: index)))
+    observer.finishEnumerating(upTo: nil)
 }
 
 final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
@@ -207,8 +362,14 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
     func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
         // Bind the Sendable stored properties to locals so the Task does not
         // capture self (a non-Sendable NSObject), per Swift 6 region isolation.
+        // Asset containers paginate: each call fetches one page and finishes with
+        // the next cursor, so the system re-enters with it. Finder paints the
+        // folder only at the final finishEnumerating, but memory stays bounded to
+        // one page, which is what lets very large folders load at all.
         let container = self.container
         let cache = self.cache
+        let client = self.client
+        let page = page
         // The system's enumeration observer is not Sendable but is documented to
         // accept callbacks from any thread, so crossing into the Task is safe.
         nonisolated(unsafe) let observer = observer
@@ -231,10 +392,7 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
                     })
                     observer.finishEnumerating(upTo: nil)
                 case .album(let id):
-                    let assets = try await cache.assets(for: .album(id: id))
-                    fileProviderLog.log("enumerated \(assets.count, privacy: .public) assets in album")
-                    observer.didEnumerate(immichItems(from: assets, location: .album(id: id)))
-                    observer.finishEnumerating(upTo: nil)
+                    try await enumerateAssetContainer(.album(id: id), cache: cache, client: client, page: page, observer: observer)
                 case .years:
                     let years = try await cache.timelineYears()
                     fileProviderLog.log("enumerated \(years.count, privacy: .public) timeline years")
@@ -246,10 +404,7 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
                     observer.didEnumerate(months.map { MonthItem(yearMonth: $0) })
                     observer.finishEnumerating(upTo: nil)
                 case .month(let yearMonth):
-                    let assets = try await cache.assets(for: .month(yearMonth: yearMonth))
-                    fileProviderLog.log("timeline \(yearMonth, privacy: .public): \(assets.count, privacy: .public) assets")
-                    observer.didEnumerate(immichItems(from: assets, location: .month(yearMonth: yearMonth)))
-                    observer.finishEnumerating(upTo: nil)
+                    try await enumerateAssetContainer(.month(yearMonth: yearMonth), cache: cache, client: client, page: page, observer: observer)
                 case .people:
                     let people = try await cache.peopleList()
                     let counts = nameCounts(people.map { $0.name ?? "" })
@@ -260,10 +415,7 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
                     })
                     observer.finishEnumerating(upTo: nil)
                 case .person(let id):
-                    let assets = try await cache.assets(for: .person(id: id))
-                    fileProviderLog.log("person \(id, privacy: .public): \(assets.count, privacy: .public) assets")
-                    observer.didEnumerate(immichItems(from: assets, location: .person(id: id)))
-                    observer.finishEnumerating(upTo: nil)
+                    try await enumerateAssetContainer(.person(id: id), cache: cache, client: client, page: page, observer: observer)
                 case .countries:
                     let places = try await cache.cityList()
                     let countries = Set(places.map { $0.country }).sorted()
@@ -277,10 +429,7 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
                     observer.didEnumerate(cities.map { FolderItem(id: .city(country: country, city: $0), parent: .country(country), filename: $0) })
                     observer.finishEnumerating(upTo: nil)
                 case .place(let country, let city):
-                    let assets = try await cache.assets(for: .place(country: country, city: city))
-                    fileProviderLog.log("place \(city, privacy: .public): \(assets.count, privacy: .public) assets")
-                    observer.didEnumerate(immichItems(from: assets, location: .place(country: country, city: city)))
-                    observer.finishEnumerating(upTo: nil)
+                    try await enumerateAssetContainer(.place(country: country, city: city), cache: cache, client: client, page: page, observer: observer)
                 case .tags:
                     let tags = try await cache.tagList()
                     let counts = nameCounts(tags.map { $0.name })
@@ -291,15 +440,17 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
                     })
                     observer.finishEnumerating(upTo: nil)
                 case .tag(let id):
-                    let assets = try await cache.assets(for: .tag(id: id))
-                    fileProviderLog.log("tag \(id, privacy: .public): \(assets.count, privacy: .public) assets")
-                    observer.didEnumerate(immichItems(from: assets, location: .tag(id: id)))
-                    observer.finishEnumerating(upTo: nil)
+                    try await enumerateAssetContainer(.tag(id: id), cache: cache, client: client, page: page, observer: observer)
                 case .favorites:
-                    let assets = try await cache.assets(for: .favorite)
-                    fileProviderLog.log("enumerated \(assets.count, privacy: .public) favorites")
-                    observer.didEnumerate(immichItems(from: assets, location: .favorite))
-                    observer.finishEnumerating(upTo: nil)
+                    try await enumerateAssetContainer(.favorite, cache: cache, client: client, page: page, observer: observer)
+                case .chunk(let location, let index):
+                    try await enumerateChunkPage(location, index: index, client: client, observer: observer)
+                case .dateYear(let location, let year):
+                    try await enumerateDateContainer(location, node: .year(year), cache: cache, observer: observer)
+                case .dateMonth(let location, let yearMonth):
+                    try await enumerateDateContainer(location, node: .month(yearMonth), cache: cache, observer: observer)
+                case .datePage(let location, let yearMonth, let pageIndex):
+                    try await enumerateDateContainer(location, node: .page(month: yearMonth, index: pageIndex), cache: cache, observer: observer)
                 }
             } catch {
                 fileProviderLog.error("enumeration failed for \(String(describing: container), privacy: .public): \(String(describing: error), privacy: .public)")
@@ -308,11 +459,20 @@ final class ItemEnumerator: NSObject, NSFileProviderEnumerator {
         }
     }
 
+    // Findich does not drive a per-folder change feed. In the replicated model the
+    // system only honors working-set signals and paints a folder only at its final
+    // finishEnumerating, so a change round reports nothing against the same anchor.
     func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
         observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
     }
 
+    // No sync anchor: Findich has no incremental change feed. A nil anchor makes
+    // the system re-run the full enumerateItems on every reopen and after every
+    // signalEnumerator, instead of calling the no-op enumerateChanges. A constant
+    // non-nil anchor (what this used to return) wrongly told the system the
+    // container never changes, so it stopped re-enumerating and served a stale or
+    // empty snapshot (folders not painting until you left and came back).
     func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-        completionHandler(NSFileProviderSyncAnchor(Data("anchor-v1".utf8)))
+        completionHandler(nil)
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ Why pay-what-you-want? Shipping a Mac app outside the App Store needs an Apple D
 
 ## How it works
 
-- A small **container app** (`ImmichDrive`) registers a File Provider _domain_ and stores your server URL + API key (App Group `UserDefaults` + Keychain).
+- A small **container app** (`ImmichDrive`) registers a File Provider _domain_ and stores your server URL + API key (App Group `UserDefaults` + Keychain). Its **Options** tab controls how large folders appear and reclaims disk:
+  - **Split large folders**: a folder over the chosen size is shown as sub-folders so each loads on its own. _Pages_ makes numbered slices (`0001-1000`, …); _Year & month_ groups by capture date (Places and Timeline months always use pages). Takes effect on the next Update.
+  - **Free up space**: reverts downloaded originals back to placeholders to reclaim disk; they re-download when next opened, and files in use are kept.
 - A **File Provider extension** (`NSFileProviderReplicatedExtension`) does the real work: enumerating albums and assets, serving thumbnails, and downloading originals on demand.
-- Both talk to Immich's REST API (`/api/albums`, `/api/assets/{id}/original`, `/api/assets/{id}/thumbnail`, …) using the `x-api-key` header.
+- Both talk to Immich's REST API (`/api/albums`, `/api/assets/{id}/original`, `/api/assets/{id}/thumbnail`, `/api/search/statistics`, …) using the `x-api-key` header.
 
 Note: photos Immich indexes from an **external library** are read-only. Findich browses and downloads them like any other asset, but it can't write them back; Immich owns those files and refreshes them from the source itself. Findich doesn't single them out in Finder yet, so a delete or move you try there just won't take.
 
@@ -147,6 +149,8 @@ The extension's `Info.plist` **must** include `NSExtensionFileProviderDocumentGr
 - [x] `Places/` view: `Country/City/` hierarchy (geocoding)
 - [x] `Tags/` view: tags as folders (`tagIds`)
 - [x] `Favorites/` view: favorited assets, flat (`isFavorite`)
+- [x] Options tab: split large folders into pages or year/month groups
+- [x] Free up space: evict downloaded originals back to placeholders
 - [ ] Full two-way sync: pull remote changes via `enumerateChanges` + sync anchors
 
 ## Releasing
@@ -179,10 +183,15 @@ Some behavior (the real Keychain, Sparkle, the Finder extension) needs a signed 
 5. Keychain: no keychain prompt during or after the update.
 6. Finder: "Findich" is still in the sidebar.
 7. File Provider: browse an album, open a photo (download), drag a file in (upload).
-8. Lock then unlock the screen, then browse again with no auth error.
-9. CI is green on the commit (pure logic plus the appcast generator test).
+8. Options → Split large folders (Pages): a large album shows numbered sub-folders; open one and confirm photos download.
+9. Options → Group by Year & month: the same album shows year/month folders.
+10. Options → Free up space: after downloading a few originals, confirm they revert to placeholders.
+11. Lock then unlock the screen, then browse again with no auth error.
+12. CI is green on the commit (pure logic plus the appcast generator test).
 
 ## Security usage note
+
+**Plain-HTTP servers expose your API key.** Findich allows cleartext connections so it can reach self-hosted servers without TLS (LAN IPs, Tailscale, reverse proxies). If your server URL is `http://` rather than `https://`, your Immich API key is sent unencrypted on every request, so anyone who can observe the network between you and the server can capture it (and that key grants full access to your library). On an untrusted network, use an `https://` URL or a tunnel such as Tailscale that encrypts the transport.
 
 As with any software, there may still be bugs, edge-case errors, or incomplete hardening details. We aim to keep behavior safe, stable, and security-aware, but no software is perfect. We used AI models as a drafting and review aid during implementation.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Findich/                     ← appears in the Finder sidebar
 
 Build it from source (see [Setup](#setup)) for free, or download a ready-to-run, signed and notarized build from [Gumroad](https://withquub.gumroad.com/l/grbwny). It's pay-what-you-want, and zero is a valid price.
 
+### Homebrew
+
+```bash
+brew tap majorfi/tap && brew trust majorfi/tap && brew install --cask findich
+```
+
+`brew trust` is a one-time confirmation Homebrew 6+ asks for any third-party tap. This installs the same signed, notarized build from GitHub Releases; the app updates itself (Sparkle), so `brew upgrade` leaves it alone.
+
 Why pay-what-you-want? Shipping a Mac app outside the App Store needs an Apple Developer Program membership ($99/year), plus Developer-ID signing and Apple notarization so Gatekeeper doesn't block it on first launch. The source is open and free to build yourself; the paid build just saves you the Xcode round-trip and helps cover those running costs.
 
 ## How it works

--- a/Shared/AppGroup.swift
+++ b/Shared/AppGroup.swift
@@ -15,6 +15,9 @@ enum AppGroup {
     enum DefaultsKey {
         static let baseURL = "immich.baseURL"
         static let visibleSections = "immich.visibleSections"
+        static let chunkingEnabled = "immich.chunkingEnabled"
+        static let chunkSize = "immich.chunkSize"
+        static let chunkStrategy = "immich.chunkStrategy"
     }
 
     static var defaults: UserDefaults? {

--- a/Shared/ChunkingSettings.swift
+++ b/Shared/ChunkingSettings.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// When a folder holds more than `threshold` assets, the extension splits it into
+// When a folder holds more than `size` assets, the extension splits it into
 // fixed-size sub-folders ("chunks") of `size` assets each, so a very large album
 // shows as a handful of folders that each paint independently instead of one
 // folder that must fully materialize before Finder draws anything. Opt-in:
@@ -36,6 +36,18 @@ struct ChunkingSettings: Sendable, Equatable {
             size: size,
             strategy: strategy
         )
+    }
+
+    // Allowed page sizes. The Options stepper uses this, and the app clamps the
+    // free-form size field to it before saving, so a typed value can't persist
+    // out of range and then read back as the default (which looks like the field
+    // is being ignored).
+    static let sizeRange = 100...10_000
+
+    func clampedToValidSize() -> ChunkingSettings {
+        var copy = self
+        copy.size = min(max(size, ChunkingSettings.sizeRange.lowerBound), ChunkingSettings.sizeRange.upperBound)
+        return copy
     }
 
     static func save(_ settings: ChunkingSettings) {

--- a/Shared/ChunkingSettings.swift
+++ b/Shared/ChunkingSettings.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+// When a folder holds more than `threshold` assets, the extension splits it into
+// fixed-size sub-folders ("chunks") of `size` assets each, so a very large album
+// shows as a handful of folders that each paint independently instead of one
+// folder that must fully materialize before Finder draws anything. Opt-in:
+// absent (first run) means disabled, and behavior matches the flat folders.
+// How a large folder is divided. `pages` is the flat numbered slices; `date`
+// groups by year then month (collapsing single-value levels), splitting a month
+// into pages only when it itself exceeds the page size.
+enum ChunkStrategy: String, Sendable, CaseIterable {
+    case pages
+    case date
+}
+
+struct ChunkingSettings: Sendable, Equatable {
+    var enabled: Bool
+    var size: Int
+    var strategy: ChunkStrategy = .pages
+
+    static let `default` = ChunkingSettings(enabled: false, size: 1000, strategy: .pages)
+
+    static func load() -> ChunkingSettings {
+        guard let defaults = AppGroup.defaults else {
+            return .default
+        }
+        guard defaults.object(forKey: AppGroup.DefaultsKey.chunkingEnabled) != nil else {
+            return .default
+        }
+        let storedSize = defaults.integer(forKey: AppGroup.DefaultsKey.chunkSize)
+        let size: Int = if storedSize > 0 { storedSize } else { ChunkingSettings.default.size }
+        let storedStrategy = defaults.string(forKey: AppGroup.DefaultsKey.chunkStrategy)
+        let strategy = storedStrategy.flatMap(ChunkStrategy.init(rawValue:)) ?? .pages
+        return ChunkingSettings(
+            enabled: defaults.bool(forKey: AppGroup.DefaultsKey.chunkingEnabled),
+            size: size,
+            strategy: strategy
+        )
+    }
+
+    static func save(_ settings: ChunkingSettings) {
+        guard let defaults = AppGroup.defaults else {
+            return
+        }
+        defaults.set(settings.enabled, forKey: AppGroup.DefaultsKey.chunkingEnabled)
+        defaults.set(settings.size, forKey: AppGroup.DefaultsKey.chunkSize)
+        defaults.set(settings.strategy.rawValue, forKey: AppGroup.DefaultsKey.chunkStrategy)
+    }
+
+    // A folder count this large is never a real library; it only happens when a
+    // hostile or buggy server reports a huge total. Capping it keeps the page
+    // arithmetic from overflowing and stops enumeration from allocating unbounded
+    // folder items.
+    static let maxChunkFolders = 50_000
+
+    // Number of chunk folders a container of `count` assets splits into, and the
+    // 0-based index of the chunk holding the asset at global position `assetIndex`.
+    // Both halves of the design (listing folders, resolving an asset's parent) go
+    // through this so they can never disagree on the boundaries. The count comes
+    // from the server, so the math is done by division (never `count + size`,
+    // which can overflow) and the result is capped.
+    func chunkCount(for count: Int) -> Int {
+        guard size > 0, count > 0 else {
+            return 1
+        }
+        let folders = (count - 1) / size + 1
+        return min(folders, ChunkingSettings.maxChunkFolders)
+    }
+
+    // Clamped so an asset never maps to a chunk folder that was not listed, even
+    // if the statistics count and the fetched membership drift by a few items.
+    func chunkIndex(forAssetIndex assetIndex: Int, count: Int) -> Int {
+        guard size > 0 else {
+            return 0
+        }
+        return min(assetIndex / size, chunkCount(for: count) - 1)
+    }
+
+    // A folder is split only when it spans more than one page, so a folder of
+    // `size` or fewer stays flat and there is never a lone single-page sub-folder.
+    func isChunked(count: Int) -> Bool {
+        return enabled && count > size
+    }
+}

--- a/Shared/DateChunkLayout.swift
+++ b/Shared/DateChunkLayout.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+// A node in the date strategy's folder tree. A year or month folder, or one page
+// of a month that is itself too large. The enumerator maps these to identifiers
+// and folder items; the layout stays free of FileProvider so it is unit-testable.
+enum DateChunkNode: Sendable, Hashable {
+    case year(String)                    // "2024"
+    case month(String)                   // "2024-03"
+    case page(month: String, index: Int) // page `index` within a month
+}
+
+// What a container shows: either sub-folders, or the assets of a single month
+// directly (when that level collapsed down to one non-paged month).
+enum DateChunkChildren: Sendable, Equatable {
+    case folders([DateChunkNode])
+    case assets(month: String)
+}
+
+// Pure, deterministic shape of the date tree for one container: given each
+// month's count and the page size, it decides which levels exist (collapsing any
+// level that has a single value) and where every asset's parent folder is. The
+// enumerator (listing folders) and the resolver (an asset's parent) both ask the
+// same layout, so they cannot disagree on the structure.
+struct DateChunkLayout: Sendable, Equatable {
+    let monthCounts: [String: Int]
+    let size: Int
+
+    // "YYYY-MM" of an asset, taken straight from the stored capture date. Using
+    // one source for grouping and resolution avoids any timezone divergence a
+    // server-side date bucket could introduce.
+    static func month(of asset: Asset) -> String {
+        String(asset.fileCreatedAt.prefix(7))
+    }
+
+    static func counts(of assets: [Asset]) -> [String: Int] {
+        var counts: [String: Int] = [:]
+        for asset in assets {
+            counts[month(of: asset), default: 0] += 1
+        }
+        return counts
+    }
+
+    private func year(of month: String) -> String {
+        String(month.prefix(4))
+    }
+
+    var years: [String] {
+        Set(monthCounts.keys.map { String($0.prefix(4)) }).sorted(by: >)
+    }
+
+    func months(in year: String) -> [String] {
+        monthCounts.keys.filter { $0.hasPrefix("\(year)-") }.sorted(by: >)
+    }
+
+    var hasYearLevel: Bool {
+        years.count > 1
+    }
+
+    func hasMonthLevel(year: String) -> Bool {
+        months(in: year).count > 1
+    }
+
+    func count(month: String) -> Int {
+        monthCounts[month] ?? 0
+    }
+
+    func isPaged(month: String) -> Bool {
+        count(month: month) > size
+    }
+
+    func pageCount(month: String) -> Int {
+        let monthCount = count(month: month)
+        guard size > 0, monthCount > 0 else {
+            return 1
+        }
+        return (monthCount - 1) / size + 1
+    }
+
+    // What the top container (album/person/tag/favorite) shows, after collapsing
+    // single-value levels: years, or a single year's months, or a single month's
+    // pages or assets.
+    func rootChildren() -> DateChunkChildren {
+        if hasYearLevel {
+            return .folders(years.map { .year($0) })
+        }
+        guard let onlyYear = years.first else {
+            return .folders([])
+        }
+        return yearChildren(onlyYear)
+    }
+
+    func yearChildren(_ year: String) -> DateChunkChildren {
+        let ms = months(in: year)
+        if ms.count > 1 {
+            return .folders(ms.map { .month($0) })
+        }
+        guard let onlyMonth = ms.first else {
+            return .folders([])
+        }
+        return monthChildren(onlyMonth)
+    }
+
+    func monthChildren(_ month: String) -> DateChunkChildren {
+        if isPaged(month: month) {
+            return .folders((0..<pageCount(month: month)).map { .page(month: month, index: $0) })
+        }
+        return .assets(month: month)
+    }
+
+    // The folder a node lives under, or nil for the top container. A node's parent
+    // is the deepest level that still exists after collapsing.
+    func parentNode(of node: DateChunkNode) -> DateChunkNode? {
+        switch node {
+        case .year:
+            return nil
+        case .month(let month):
+            if hasYearLevel {
+                return .year(year(of: month))
+            }
+            return nil
+        case .page(let month, _):
+            if hasMonthLevel(year: year(of: month)) {
+                return .month(month)
+            }
+            if hasYearLevel {
+                return .year(year(of: month))
+            }
+            return nil
+        }
+    }
+
+    // The folder an asset reports as its parent, given its month and its position
+    // within that month (0-based). nil means the asset hangs directly off the top
+    // container. Mirrors monthChildren/parentNode so listing and resolution agree.
+    func assetParentNode(month: String, indexInMonth: Int) -> DateChunkNode? {
+        if isPaged(month: month) {
+            return .page(month: month, index: indexInMonth / max(1, size))
+        }
+        if hasMonthLevel(year: year(of: month)) {
+            return .month(month)
+        }
+        if hasYearLevel {
+            return .year(year(of: month))
+        }
+        return nil
+    }
+}

--- a/Shared/ImmichClient.swift
+++ b/Shared/ImmichClient.swift
@@ -375,7 +375,10 @@ struct ImmichClient: Sendable {
     // the request to a different endpoint. Immich ids are UUIDs, so this is a no-op
     // for honest data.
     private func pathSegment(_ value: String) -> String {
-        value.addingPercentEncoding(withAllowedCharacters: ImmichClient.pathSegmentAllowed) ?? ""
+        // Encoding only returns nil for malformed unicode (which cannot contain the
+        // path-special characters this guards against), so fall back to the value
+        // unchanged rather than to "", which would collapse the path (e.g. //).
+        value.addingPercentEncoding(withAllowedCharacters: ImmichClient.pathSegmentAllowed) ?? value
     }
 
     // MARK: - Retry / backoff

--- a/Shared/ImmichClient.swift
+++ b/Shared/ImmichClient.swift
@@ -22,6 +22,27 @@ enum HTTPMethod: String, Sendable { case get = "GET"; case put = "PUT"; case pos
 struct SearchPage: Sendable {
     let assets: [Asset]
     let nextPage: String?
+
+    // A page has a successor only when the server reports a next page and the
+    // current page was non-empty, the same termination the full-list pager uses.
+    var hasMore: Bool {
+        nextPage != nil && assets.isEmpty == false
+    }
+}
+
+// Every asset container, keyed for paged /search/metadata streaming. All six
+// locations (albums included) enumerate and resolve through the same paged
+// /search/metadata path, so listing and single-asset resolution stay consistent.
+// One consequence: /search/metadata applies the default visibility filter, so an
+// album made of archived assets lists and resolves empty (the unpaged album
+// endpoint that includes archived now backs only the integration tests).
+enum AssetSearch: Sendable {
+    case album(id: String)
+    case month(yearMonth: String)
+    case person(id: String)
+    case place(country: String, city: String)
+    case tag(id: String)
+    case favorite
 }
 
 struct ImmichClient: Sendable {
@@ -44,11 +65,11 @@ struct ImmichClient: Sendable {
     }
 
     func downloadOriginal(assetID: String) async throws -> Data {
-        try await getBytes(path: "/api/assets/\(assetID)/original")
+        try await getBytes(path: "/api/assets/\(pathSegment(assetID))/original")
     }
 
     func downloadThumbnail(assetID: String, size: String?) async throws -> Data {
-        var path = "/api/assets/\(assetID)/thumbnail"
+        var path = "/api/assets/\(pathSegment(assetID))/thumbnail"
         if let size, size.isEmpty == false {
             path += "?size=\(size)"
         }
@@ -110,11 +131,17 @@ struct ImmichClient: Sendable {
                         prefix.appendString("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
                         prefix.appendString("\(value)\r\n")
                     }
+                    // Strip quote and CR/LF so a crafted filename can't break out of
+                    // the Content-Disposition header or inject extra multipart headers.
+                    let headerFilename = filename
+                        .replacingOccurrences(of: "\"", with: "")
+                        .replacingOccurrences(of: "\r", with: "")
+                        .replacingOccurrences(of: "\n", with: "")
                     prefix.appendString("--\(boundary)\r\n")
-                    prefix.appendString("Content-Disposition: form-data; name=\"assetData\"; filename=\"\(filename)\"\r\n")
+                    prefix.appendString("Content-Disposition: form-data; name=\"assetData\"; filename=\"\(headerFilename)\"\r\n")
                     prefix.appendString("Content-Type: application/octet-stream\r\n\r\n")
 
-                    FileManager.default.createFile(atPath: url.path, contents: nil)
+                    FileManager.default.createFile(atPath: url.path, contents: nil, attributes: [.posixPermissions: 0o600])
                     let writer = try FileHandle(forWritingTo: url)
                     defer { try? writer.close() }
                     try writer.write(contentsOf: prefix)
@@ -133,15 +160,15 @@ struct ImmichClient: Sendable {
     }
 
     func addAssets(albumID: String, assetIDs: [String]) async throws {
-        _ = try await sendJSON(method: .put, path: "/api/albums/\(albumID)/assets", body: AssetIDsRequest(ids: assetIDs))
+        _ = try await sendJSON(method: .put, path: "/api/albums/\(pathSegment(albumID))/assets", body: AssetIDsRequest(ids: assetIDs))
     }
 
     func removeAssets(albumID: String, assetIDs: [String]) async throws {
-        _ = try await sendJSON(method: .delete, path: "/api/albums/\(albumID)/assets", body: AssetIDsRequest(ids: assetIDs))
+        _ = try await sendJSON(method: .delete, path: "/api/albums/\(pathSegment(albumID))/assets", body: AssetIDsRequest(ids: assetIDs))
     }
 
     func renameAlbum(ID: String, name: String) async throws -> AlbumSummary {
-        let data = try await sendJSON(method: .patch, path: "/api/albums/\(ID)", body: UpdateAlbumRequest(albumName: name))
+        let data = try await sendJSON(method: .patch, path: "/api/albums/\(pathSegment(ID))", body: UpdateAlbumRequest(albumName: name))
         return try JSONDecoder().decode(AlbumSummary.self, from: data)
     }
 
@@ -162,7 +189,7 @@ struct ImmichClient: Sendable {
 
     // Removes the album grouping; the assets it held stay in the library.
     func deleteAlbum(ID: String) async throws {
-        _ = try await send(method: .delete, path: "/api/albums/\(ID)")
+        _ = try await send(method: .delete, path: "/api/albums/\(pathSegment(ID))")
     }
 
     func searchMetadata(takenAfter: String? = nil, takenBefore: String? = nil, albumIDs: [String]? = nil, personIDs: [String]? = nil, tagIDs: [String]? = nil, isFavorite: Bool? = nil, city: String? = nil, country: String? = nil, page: Int, size: Int, order: SortOrder) async throws -> SearchPage {
@@ -171,16 +198,63 @@ struct ImmichClient: Sendable {
         return SearchPage(assets: response.assets.items, nextPage: response.assets.nextPage)
     }
 
-    // Pages through /api/search/metadata until exhausted, gathering every asset
-    // matching the filter. Backs both the month (timeline) and album views, so
-    // album enumeration is bounded by page size instead of one unbounded fetch.
-    private func searchAll(albumIDs: [String]? = nil, personIDs: [String]? = nil, tagIDs: [String]? = nil, isFavorite: Bool? = nil, city: String? = nil, country: String? = nil, takenAfter: String? = nil, takenBefore: String? = nil) async throws -> [Asset] {
+    // Fetches exactly one /search/metadata page for a location, so enumeration can
+    // fill a folder a page at a time: each call hands back the next-page cursor and
+    // the system re-enters enumerateItems with it. The page is 1-based; the size is
+    // the caller's choice. order: .asc matches searchAllViaPage so paging stays
+    // stable across calls (no item shifts across a page boundary).
+    func searchPage(for location: AssetSearch, page: Int, size: Int) async throws -> SearchPage {
+        switch location {
+        case .album(let id):
+            return try await searchMetadata(albumIDs: [id], page: page, size: size, order: .asc)
+        case .month(let yearMonth):
+            let bounds = ImmichClient.monthBounds(yearMonth)
+            return try await searchMetadata(takenAfter: bounds.after, takenBefore: bounds.before, page: page, size: size, order: .asc)
+        case .person(let id):
+            return try await searchMetadata(personIDs: [id], page: page, size: size, order: .asc)
+        case .place(let country, let city):
+            return try await searchMetadata(city: city, country: country, page: page, size: size, order: .asc)
+        case .tag(let id):
+            return try await searchMetadata(tagIDs: [id], page: page, size: size, order: .asc)
+        case .favorite:
+            return try await searchMetadata(isFavorite: true, page: page, size: size, order: .asc)
+        }
+    }
+
+    // Total number of assets a location holds, from POST /api/search/statistics.
+    // Mirrors the searchPage filter mapping so the count matches exactly what
+    // enumeration would page through (same visibility filter, archived excluded).
+    // Used to decide how many chunk folders a large container splits into.
+    func searchStatistics(for location: AssetSearch) async throws -> Int {
+        let request: StatisticsSearchRequest
+        switch location {
+        case .album(let id):
+            request = StatisticsSearchRequest(albumIds: [id])
+        case .month(let yearMonth):
+            let bounds = ImmichClient.monthBounds(yearMonth)
+            request = StatisticsSearchRequest(takenAfter: bounds.after, takenBefore: bounds.before)
+        case .person(let id):
+            request = StatisticsSearchRequest(personIds: [id])
+        case .place(let country, let city):
+            request = StatisticsSearchRequest(city: city, country: country)
+        case .tag(let id):
+            request = StatisticsSearchRequest(tagIds: [id])
+        case .favorite:
+            request = StatisticsSearchRequest(isFavorite: true)
+        }
+        let response: SearchStatisticsResponse = try await postJSON(path: "/api/search/statistics", body: request)
+        return max(0, response.total)
+    }
+
+    // Fetches every asset for a location by paging /search/metadata at the given
+    // size to the end. The folder enumeration loads its full membership this way.
+    func searchAllViaPage(for location: AssetSearch, size: Int) async throws -> [Asset] {
         var all: [Asset] = []
         var page = 1
         while true {
-            let result = try await searchMetadata(takenAfter: takenAfter, takenBefore: takenBefore, albumIDs: albumIDs, personIDs: personIDs, tagIDs: tagIDs, isFavorite: isFavorite, city: city, country: country, page: page, size: 1000, order: .asc)
+            let result = try await searchPage(for: location, page: page, size: size)
             all.append(contentsOf: result.assets)
-            guard result.nextPage != nil, result.assets.isEmpty == false else {
+            if result.hasMore == false {
                 break
             }
             page += 1
@@ -188,37 +262,16 @@ struct ImmichClient: Sendable {
         return all
     }
 
-    func searchAllMonth(yearMonth: String) async throws -> [Asset] {
-        let bounds = ImmichClient.monthBounds(yearMonth)
-        return try await searchAll(takenAfter: bounds.after, takenBefore: bounds.before)
-    }
-
     // Album membership comes from the album endpoint, not /search/metadata: the
     // latter applies the default visibility filter and drops archived assets, so
     // an album of archived photos would enumerate empty.
     func searchAllAlbum(albumID: String) async throws -> [Asset] {
-        let detail: AlbumDetail = try await getJSON(path: "/api/albums/\(albumID)")
+        let detail: AlbumDetail = try await getJSON(path: "/api/albums/\(pathSegment(albumID))")
         return detail.assets
-    }
-
-    func searchAllPerson(personID: String) async throws -> [Asset] {
-        try await searchAll(personIDs: [personID])
-    }
-
-    func searchAllCity(country: String, city: String) async throws -> [Asset] {
-        try await searchAll(city: city, country: country)
-    }
-
-    func searchAllTag(tagID: String) async throws -> [Asset] {
-        try await searchAll(tagIDs: [tagID])
     }
 
     func listTags() async throws -> [TagSummary] {
         try await getJSON(path: "/api/tags")
-    }
-
-    func searchAllFavorites() async throws -> [Asset] {
-        try await searchAll(isFavorite: true)
     }
 
     // Distinct (country, city) places. The cities endpoint returns one
@@ -313,6 +366,16 @@ struct ImmichClient: Sendable {
         var request = URLRequest(url: url)
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         return request
+    }
+
+    private static let pathSegmentAllowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+
+    // Percent-encodes a server-provided id before it goes into a request path, so a
+    // hostile id (one containing /, ?, #, or ..) cannot reframe the path or route
+    // the request to a different endpoint. Immich ids are UUIDs, so this is a no-op
+    // for honest data.
+    private func pathSegment(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: ImmichClient.pathSegmentAllowed) ?? ""
     }
 
     // MARK: - Retry / backoff

--- a/Shared/ImmichModels.swift
+++ b/Shared/ImmichModels.swift
@@ -120,6 +120,25 @@ struct MetadataSearchRequest: Encodable, Sendable {
     let withExif: Bool
 }
 
+// POST /api/search/statistics: the same filter set as MetadataSearchRequest but
+// without paging, returning just the total match count. This is the count source
+// for chunked folders; the search response's own `total` is deprecated since
+// v3.0.0, so the statistics endpoint is used instead.
+struct StatisticsSearchRequest: Encodable, Sendable {
+    var takenAfter: String? = nil
+    var takenBefore: String? = nil
+    var albumIds: [String]? = nil
+    var personIds: [String]? = nil
+    var tagIds: [String]? = nil
+    var isFavorite: Bool? = nil
+    var city: String? = nil
+    var country: String? = nil
+}
+
+struct SearchStatisticsResponse: Decodable, Sendable {
+    let total: Int
+}
+
 enum UploadStatus: String, Decodable, Sendable {
     case created
     case replaced

--- a/Shared/README.md
+++ b/Shared/README.md
@@ -7,4 +7,6 @@ Code compiled into both targets, the [app](../App) and the [File Provider extens
 - `CredentialStore.swift`: reads and writes the server URL and API key in the Keychain, shared through the App Group.
 - `AppGroup.swift`: the shared App Group, domain, and UserDefaults identifiers.
 - `VisibleSections.swift`: which top-level folders appear in Finder, persisted in App Group defaults.
+- `ChunkingSettings.swift`: how a large folder splits (Pages or Year & month, and the page size), persisted in App Group defaults. The page-boundary math here is shared by enumeration and an asset's parent resolution, so they cannot disagree.
+- `DateChunkLayout.swift`: the pure year/month/page tree for the date strategy, derived from each asset's capture month so listing a folder and resolving an asset's parent always agree. No FileProvider dependency, so it is unit-tested directly.
 - `DomainRegistration.swift`: the add and remove-then-retry logic for registering the domain, factored out so it can be tested without `NSFileProviderManager`.

--- a/Tests/ChunkingTests.swift
+++ b/Tests/ChunkingTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+import FileProvider
+
+final class ChunkingTests: XCTestCase {
+    override func tearDown() {
+        MockURLProtocol.handler = nil
+        ChunkingSettings.save(.default)
+    }
+
+    // MARK: - Pure chunk math
+
+    func testChunkCountRoundsUp() {
+        let settings = ChunkingSettings(enabled: true, size: 100)
+        XCTAssertEqual(settings.chunkCount(for: 250), 3)
+        XCTAssertEqual(settings.chunkCount(for: 200), 2)
+        XCTAssertEqual(settings.chunkCount(for: 1), 1)
+        XCTAssertEqual(settings.chunkCount(for: 0), 1)
+    }
+
+    func testChunkIndexIsPositionOverSize() {
+        let settings = ChunkingSettings(enabled: true, size: 100)
+        XCTAssertEqual(settings.chunkIndex(forAssetIndex: 0, count: 250), 0)
+        XCTAssertEqual(settings.chunkIndex(forAssetIndex: 99, count: 250), 0)
+        XCTAssertEqual(settings.chunkIndex(forAssetIndex: 100, count: 250), 1)
+        XCTAssertEqual(settings.chunkIndex(forAssetIndex: 249, count: 250), 2)
+    }
+
+    // An asset whose position exceeds the counted set still maps to the last
+    // listed chunk rather than a folder that was never enumerated.
+    func testChunkIndexClampsToLastChunk() {
+        let settings = ChunkingSettings(enabled: true, size: 100)
+        XCTAssertEqual(settings.chunkIndex(forAssetIndex: 400, count: 250), 2)
+    }
+
+    // A hostile or buggy server count must not overflow the page arithmetic or
+    // make the folder count unbounded.
+    func testChunkCountIsOverflowSafeAndCapped() {
+        let settings = ChunkingSettings(enabled: true, size: 1000)
+        XCTAssertEqual(settings.chunkCount(for: Int.max), ChunkingSettings.maxChunkFolders)
+        XCTAssertEqual(settings.chunkCount(for: -5), 1)
+        XCTAssertEqual(settings.chunkCount(for: 0), 1)
+        XCTAssertEqual(settings.chunkCount(for: 2500), 3)
+    }
+
+    // A crafted/stale identifier index must clamp into the valid page range instead
+    // of trapping on `index * size`.
+    func testChunkSliceClampsCraftedIndex() {
+        let huge = chunkSlice(index: .max, size: 1000, total: 2500)
+        XCTAssertTrue(huge.lowerBound >= 0 && huge.upperBound <= 2500 && huge.lowerBound <= huge.upperBound)
+        XCTAssertEqual(chunkSlice(index: 99, size: 1000, total: 2500), 2000..<2500)
+        XCTAssertEqual(chunkSlice(index: 0, size: 1000, total: 2500), 0..<1000)
+        XCTAssertEqual(chunkSlice(index: -3, size: 1000, total: 2500), 0..<1000)
+        XCTAssertEqual(chunkSlice(index: 0, size: 1000, total: 0), 0..<0)
+    }
+
+    func testChunkRangeLabelDoesNotOverflowOnHugeIndex() {
+        XCTAssertEqual(chunkRangeLabel(index: .max, size: 1000, total: 2500), "2001-2500")
+    }
+
+    func testSearchStatisticsClampsNegativeTotal() async throws {
+        let client = MockClient.make { _ in (200, Data(#"{"total":-7}"#.utf8)) }
+        let total = try await client.searchStatistics(for: .album(id: "a"))
+        XCTAssertEqual(total, 0)
+    }
+
+    func testIsChunkedRespectsToggleAndSize() {
+        let on = ChunkingSettings(enabled: true, size: 100)
+        XCTAssertTrue(on.isChunked(count: 101), "more than one page is chunked")
+        XCTAssertFalse(on.isChunked(count: 100), "exactly one page stays flat")
+        let off = ChunkingSettings(enabled: false, size: 100)
+        XCTAssertFalse(off.isChunked(count: 10_000))
+    }
+
+    // MARK: - Identifier grammar round-trips
+
+    func testAssetLocationCodeRoundTrips() {
+        let locations: [AssetLocation] = [
+            .album(id: "AL-1"),
+            .month(yearMonth: "2024-03"),
+            .person(id: "P-1"),
+            .tag(id: "T-1"),
+            .favorite,
+            .place(country: "France", city: "Paris")
+        ]
+        for location in locations {
+            guard let decoded = AssetLocation(code: location.code) else {
+                XCTFail("code did not decode: \(location.code)")
+                continue
+            }
+            XCTAssertEqual(decoded.code, location.code, "round-trip changed \(location.code)")
+        }
+    }
+
+    func testChunkIdentifierRoundTrips() {
+        let cases: [(AssetLocation, Int)] = [
+            (.album(id: "AL-1"), 0),
+            (.place(country: "France", city: "Paris"), 7),
+            (.favorite, 3)
+        ]
+        for (location, index) in cases {
+            let identifier = ItemID.chunk(location: location, index: index).identifier
+            guard case .chunk(let parsedLocation, let parsedIndex) = ItemID(identifier) else {
+                XCTFail("did not parse back to a chunk: \(identifier.rawValue)")
+                continue
+            }
+            XCTAssertEqual(parsedIndex, index)
+            XCTAssertEqual(parsedLocation.code, location.code)
+        }
+    }
+
+    // MARK: - Enumeration
+
+    private func enumerate(_ container: EnumeratedContainer, client: ImmichClient) async -> [NSFileProviderItem] {
+        let enumerator = ItemEnumerator(client: client, cache: ImmichCache(client: client), container: container)
+        let observer = MockEnumObserver()
+        enumerator.enumerateItems(for: observer, startingAt: NSFileProviderPage(Data("p".utf8)))
+        await fulfillment(of: [observer.done], timeout: 10)
+        XCTAssertNil(observer.error)
+        return observer.items
+    }
+
+    // A statistics total over the threshold makes a container enumerate chunk
+    // folders (named as zero-padded ranges) instead of assets, with no asset fetch.
+    func testLargeContainerEnumeratesChunkFolders() async {
+        ChunkingSettings.save(ChunkingSettings(enabled: true, size: 100))
+        let client = MockClient.make { req in
+            let path = req.url?.path ?? ""
+            if path == "/api/search/statistics" {
+                return (200, Data(#"{"total":250}"#.utf8))
+            }
+            return (200, Data("{}".utf8))
+        }
+        let items = await enumerate(.album(id: "a"), client: client)
+        XCTAssertEqual(items.count, 3, "250 assets at size 100 split into 3 chunk folders")
+        XCTAssertEqual(items.first?.filename, "001-100")
+        XCTAssertEqual(items.last?.filename, "201-250")
+        XCTAssertEqual(items.first?.itemIdentifier, ItemID.chunk(location: .album(id: "a"), index: 0).identifier)
+        XCTAssertEqual(items.first?.parentItemIdentifier, ItemID.album("a").identifier)
+    }
+
+    // Below the threshold the container still paginates assets directly.
+    func testSmallContainerStaysFlat() async {
+        ChunkingSettings.save(ChunkingSettings(enabled: true, size: 100))
+        let asset = Fixtures.assetJSON()
+        let client = MockClient.make { req in
+            let path = req.url?.path ?? ""
+            if path == "/api/search/statistics" {
+                return (200, Data(#"{"total":50}"#.utf8))
+            }
+            return (200, Data("{\"assets\":{\"items\":[\(asset)],\"nextPage\":null}}".utf8))
+        }
+        let items = await enumerate(.album(id: "a"), client: client)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.filename, "f.jpg", "flat enumeration yields assets, not chunk folders")
+    }
+
+    // A client whose /search/metadata returns the given (id, month) assets as one
+    // page. The date strategy slices this in memory, so it never needs a
+    // month-scoped search.
+    private func dateClient(_ assets: [(id: String, month: String)]) -> ImmichClient {
+        let items = assets.map {
+            "{\"id\":\"\($0.id)\",\"type\":\"IMAGE\",\"originalFileName\":\"\($0.id).jpg\",\"fileCreatedAt\":\"\($0.month)-15T00:00:00.000Z\"}"
+        }.joined(separator: ",")
+        let body = "{\"assets\":{\"items\":[\(items)],\"nextPage\":null}}"
+        return MockClient.make { _ in (200, Data(body.utf8)) }
+    }
+
+    private static let albumA = AssetLocation.album(id: "a")
+
+    // Date strategy, single year with several months: the album collapses straight
+    // to month folders (no year folder), parented to the album.
+    func testDateStrategyEnumeratesMonthFolders() async {
+        ChunkingSettings.save(ChunkingSettings(enabled: true, size: 2, strategy: .date))
+        let client = dateClient([("a", "2024-03"), ("b", "2024-03"), ("c", "2024-07")])
+        let items = await enumerate(.album(id: "a"), client: client)
+        XCTAssertEqual(items.count, 2)
+        XCTAssertEqual(
+            Set(items.map { $0.itemIdentifier }),
+            [ItemID.dateMonth(location: Self.albumA, yearMonth: "2024-03").identifier,
+             ItemID.dateMonth(location: Self.albumA, yearMonth: "2024-07").identifier]
+        )
+        XCTAssertTrue(items.allSatisfy { $0.parentItemIdentifier == ItemID.album("a").identifier })
+    }
+
+    // Opening a month folder delivers that month's assets, parented to the month.
+    func testDateStrategyMonthDeliversAssets() async {
+        ChunkingSettings.save(ChunkingSettings(enabled: true, size: 2, strategy: .date))
+        let client = dateClient([("a", "2024-03"), ("b", "2024-03"), ("c", "2024-07")])
+        let items = await enumerate(.dateMonth(location: Self.albumA, yearMonth: "2024-03"), client: client)
+        XCTAssertEqual(items.count, 2)
+        XCTAssertTrue(items.allSatisfy { $0.parentItemIdentifier == ItemID.dateMonth(location: Self.albumA, yearMonth: "2024-03").identifier })
+    }
+
+    // A single month bigger than the page size becomes page folders, and a page's
+    // assets report that page as parent (the date-strategy keystone).
+    func testDateStrategyPagesALargeMonth() async {
+        ChunkingSettings.save(ChunkingSettings(enabled: true, size: 2, strategy: .date))
+        let client = dateClient([("a", "2024-03"), ("b", "2024-03"), ("c", "2024-03")])
+        let root = await enumerate(.album(id: "a"), client: client)
+        XCTAssertEqual(root.count, 2, "3 assets at size 2 in one month -> 2 page folders")
+        XCTAssertEqual(root.first?.itemIdentifier, ItemID.datePage(location: Self.albumA, yearMonth: "2024-03", page: 0).identifier)
+        let page = await enumerate(.datePage(location: Self.albumA, yearMonth: "2024-03", page: 1), client: client)
+        XCTAssertEqual(page.count, 1)
+        XCTAssertEqual(page.first?.parentItemIdentifier, ItemID.datePage(location: Self.albumA, yearMonth: "2024-03", page: 1).identifier)
+    }
+
+    // The keystone: an asset enumerated inside chunk k reports that chunk as its
+    // parent, so item(for:) resolving the same asset to the same chunk agrees.
+    func testChunkAssetsReportChunkParent() async {
+        ChunkingSettings.save(ChunkingSettings(enabled: true, size: 100))
+        let asset = Fixtures.assetJSON()
+        let client = MockClient.make { req in
+            (200, Data("{\"assets\":{\"items\":[\(asset)],\"nextPage\":null}}".utf8))
+        }
+        let items = await enumerate(.chunk(location: .album(id: "a"), index: 1), client: client)
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.parentItemIdentifier, ItemID.chunk(location: .album(id: "a"), index: 1).identifier)
+        XCTAssertEqual(items.first?.itemIdentifier, ItemID.asset(albumID: "a", assetID: "x").identifier, "asset identity is unchanged by chunking")
+    }
+}

--- a/Tests/DateChunkLayoutTests.swift
+++ b/Tests/DateChunkLayoutTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+final class DateChunkLayoutTests: XCTestCase {
+
+    // Single year, single month, fits one page: the whole tree collapses to the
+    // month's assets hanging directly off the container.
+    func testSingleMonthSmallCollapsesToAssets() {
+        let layout = DateChunkLayout(monthCounts: ["2024-03": 50], size: 100)
+        XCTAssertFalse(layout.hasYearLevel)
+        XCTAssertFalse(layout.hasMonthLevel(year: "2024"))
+        XCTAssertEqual(layout.rootChildren(), .assets(month: "2024-03"))
+        XCTAssertNil(layout.assetParentNode(month: "2024-03", indexInMonth: 0))
+    }
+
+    // Single month over the page size: pages hang directly off the container, no
+    // month or year folder around them.
+    func testSingleMonthLargeCollapsesToPages() {
+        let layout = DateChunkLayout(monthCounts: ["2024-03": 250], size: 100)
+        XCTAssertEqual(layout.rootChildren(), .folders([
+            .page(month: "2024-03", index: 0),
+            .page(month: "2024-03", index: 1),
+            .page(month: "2024-03", index: 2)
+        ]))
+        XCTAssertNil(layout.parentNode(of: .page(month: "2024-03", index: 0)))
+        XCTAssertEqual(layout.assetParentNode(month: "2024-03", indexInMonth: 0), .page(month: "2024-03", index: 0))
+        XCTAssertEqual(layout.assetParentNode(month: "2024-03", indexInMonth: 150), .page(month: "2024-03", index: 1))
+    }
+
+    // One year, several months: month folders hang off the container (no year
+    // folder), and an asset's parent is its month.
+    func testSingleYearMultiMonth() {
+        let layout = DateChunkLayout(monthCounts: ["2024-03": 50, "2024-07": 80], size: 100)
+        XCTAssertFalse(layout.hasYearLevel)
+        XCTAssertTrue(layout.hasMonthLevel(year: "2024"))
+        guard case .folders(let nodes) = layout.rootChildren() else {
+            return XCTFail("expected month folders")
+        }
+        XCTAssertEqual(Set(nodes), [.month("2024-03"), .month("2024-07")])
+        XCTAssertEqual(layout.monthChildren("2024-03"), .assets(month: "2024-03"))
+        XCTAssertNil(layout.parentNode(of: .month("2024-03")))
+        XCTAssertEqual(layout.assetParentNode(month: "2024-07", indexInMonth: 0), .month("2024-07"))
+    }
+
+    // Multiple years: year folders at the top, then months inside each, with the
+    // adaptive collapse applied per year.
+    func testMultiYearNesting() {
+        let layout = DateChunkLayout(monthCounts: ["2023-05": 30, "2024-03": 50, "2024-07": 80], size: 100)
+        XCTAssertTrue(layout.hasYearLevel)
+        XCTAssertEqual(layout.rootChildren(), .folders([.year("2024"), .year("2023")]))
+        // 2024 has two months -> month folders under the year.
+        guard case .folders(let monthsOf2024) = layout.yearChildren("2024") else {
+            return XCTFail("expected month folders for 2024")
+        }
+        XCTAssertEqual(Set(monthsOf2024), [.month("2024-03"), .month("2024-07")])
+        XCTAssertEqual(layout.parentNode(of: .month("2024-03")), .year("2024"))
+        XCTAssertEqual(layout.assetParentNode(month: "2024-03", indexInMonth: 0), .month("2024-03"))
+        // 2023 has one small month -> collapses to that month's assets under the year.
+        XCTAssertEqual(layout.yearChildren("2023"), .assets(month: "2023-05"))
+        XCTAssertEqual(layout.assetParentNode(month: "2023-05", indexInMonth: 0), .year("2023"))
+    }
+
+    // Multi-year where a single-month year is itself paged: the pages hang off the
+    // year folder (month level collapsed), and assets point at those pages.
+    func testMultiYearWithPagedSingleMonth() {
+        let layout = DateChunkLayout(monthCounts: ["2023-05": 250, "2024-03": 50], size: 100)
+        XCTAssertEqual(layout.yearChildren("2023"), .folders([
+            .page(month: "2023-05", index: 0),
+            .page(month: "2023-05", index: 1),
+            .page(month: "2023-05", index: 2)
+        ]))
+        XCTAssertEqual(layout.parentNode(of: .page(month: "2023-05", index: 0)), .year("2023"))
+        XCTAssertEqual(layout.assetParentNode(month: "2023-05", indexInMonth: 120), .page(month: "2023-05", index: 1))
+        // 2024 is a single small month -> its asset collapses to the year folder.
+        XCTAssertEqual(layout.assetParentNode(month: "2024-03", indexInMonth: 0), .year("2024"))
+    }
+
+    func testCountsFromAssetsGroupByCaptureMonth() {
+        let assets = ["2024-03-01", "2024-03-31", "2024-07-15"].map(Self.decodeAsset)
+        XCTAssertEqual(DateChunkLayout.counts(of: assets), ["2024-03": 2, "2024-07": 1])
+        XCTAssertEqual(DateChunkLayout.month(of: Self.decodeAsset(date: "2024-07-15")), "2024-07")
+    }
+
+    private static func decodeAsset(date: String) -> Asset {
+        let json = Fixtures.assetJSON(date: date)
+        return try! JSONDecoder().decode(Asset.self, from: Data(json.utf8))
+    }
+}

--- a/Tests/EnumeratorTests.swift
+++ b/Tests/EnumeratorTests.swift
@@ -6,13 +6,42 @@ import FileProvider
 final class MockEnumObserver: NSObject, NSFileProviderEnumerationObserver {
     var items: [NSFileProviderItem] = []
     var error: Error?
+    var didEnumerateCalls = 0
+    var lastUpTo: NSFileProviderPage?
     let done = XCTestExpectation(description: "enumeration finished")
 
     func didEnumerate(_ updatedItems: [any NSFileProviderItemProtocol]) {
+        didEnumerateCalls += 1
         items.append(contentsOf: updatedItems)
     }
-    func finishEnumerating(upTo nextPage: NSFileProviderPage?) { done.fulfill() }
+    func finishEnumerating(upTo nextPage: NSFileProviderPage?) { lastUpTo = nextPage; done.fulfill() }
     func finishEnumeratingWithError(_ error: any Error) { self.error = error; done.fulfill() }
+}
+
+// Captures a change round: the didUpdate items and the final (anchor, moreComing)
+// the enumerator reports, so the no-op change feed can be asserted without the
+// File Provider system.
+final class MockChangeObserver: NSObject, NSFileProviderChangeObserver {
+    var updated: [NSFileProviderItem] = []
+    var deleted: [NSFileProviderItemIdentifier] = []
+    var didUpdateCalls = 0
+    var finalAnchor: NSFileProviderSyncAnchor?
+    var moreComing = false
+    let done = XCTestExpectation(description: "changes finished")
+
+    func didUpdate(_ updatedItems: [any NSFileProviderItemProtocol]) {
+        didUpdateCalls += 1
+        updated.append(contentsOf: updatedItems)
+    }
+    func didDeleteItems(withIdentifiers deletedItemIdentifiers: [NSFileProviderItemIdentifier]) {
+        deleted.append(contentsOf: deletedItemIdentifiers)
+    }
+    func finishEnumeratingChanges(upTo anchor: NSFileProviderSyncAnchor, moreComing: Bool) {
+        finalAnchor = anchor
+        self.moreComing = moreComing
+        done.fulfill()
+    }
+    func finishEnumeratingWithError(_ error: any Error) { done.fulfill() }
 }
 
 final class EnumeratorTests: XCTestCase {
@@ -60,6 +89,59 @@ final class EnumeratorTests: XCTestCase {
         }
     }
 
+    // A client whose /api/search/metadata returns nextPage:"2" on the first call
+    // and null afterwards, so a folder spans two pages.
+    private func twoPageSearchClient() -> ImmichClient {
+        let calls = AtomicInt()
+        let item = Fixtures.assetJSON()
+        return MockClient.make { _ in
+            let next: String
+            if calls.next() == 1 {
+                next = "\"2\""
+            } else {
+                next = "null"
+            }
+            return (200, Data(#"{"assets":{"items":[\#(item)],"nextPage":\#(next)}}"#.utf8))
+        }
+    }
+
+    // enumerateItems paginates: page 1 delivers its items and hands back a non-nil
+    // cursor pointing at page 2; the system re-enters with that cursor, which
+    // delivers the last page and finishes upTo nil. Only one page is held at a time.
+    func testEnumerateItemsPaginates() async {
+        let client = twoPageSearchClient()
+        let enumerator = ItemEnumerator(client: client, cache: ImmichCache(client: client), container: .favorites)
+
+        let first = MockEnumObserver()
+        enumerator.enumerateItems(for: first, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data))
+        await fulfillment(of: [first.done], timeout: 10)
+        XCTAssertNil(first.error)
+        XCTAssertEqual(first.items.count, 1, "page 1 of the two-page mock holds one item")
+        XCTAssertNotNil(first.lastUpTo, "more pages remain, so a cursor is handed back")
+        XCTAssertEqual(first.lastUpTo.map { immichPageNumber(from: $0) }, 2, "cursor points at page 2")
+
+        let second = MockEnumObserver()
+        enumerator.enumerateItems(for: second, startingAt: first.lastUpTo!)
+        await fulfillment(of: [second.done], timeout: 10)
+        XCTAssertNil(second.error)
+        XCTAssertEqual(second.items.count, 1, "page 2 delivers the remaining item")
+        XCTAssertNil(second.lastUpTo, "the last page finishes upTo nil")
+    }
+
+    // enumerateChanges is a no-op for every container: no didUpdate, finishes
+    // moreComing false against the same anchor it was given.
+    func testEnumerateChangesIsNoOp() async {
+        let client = MockClient.immichLike(citiesReturnAsset: true)
+        let enumerator = ItemEnumerator(client: client, cache: ImmichCache(client: client), container: .favorites)
+        let changes = MockChangeObserver()
+        let anchor = NSFileProviderSyncAnchor(Data("static".utf8))
+        enumerator.enumerateChanges(for: changes, from: anchor)
+        await fulfillment(of: [changes.done], timeout: 5)
+        XCTAssertEqual(changes.didUpdateCalls, 0, "no incremental change feed")
+        XCTAssertFalse(changes.moreComing)
+        XCTAssertEqual(changes.finalAnchor?.rawValue, anchor.rawValue)
+    }
+
     // The sections container honours the visible-folders setting.
     func testSectionsRespectVisibility() async {
         VisibleSections.save([.albums])
@@ -79,12 +161,14 @@ final class EnumeratorTests: XCTestCase {
         XCTAssertNotNil(observer.error)
     }
 
-    func testSyncAnchorIsTheStableSentinel() async {
+    // currentSyncAnchor returns nil: with no change feed, the system re-runs the
+    // full enumerateItems on every reopen rather than asking for deltas.
+    func testSyncAnchorIsNil() async {
         let client = MockClient.immichLike(citiesReturnAsset: true)
-        let enumerator = ItemEnumerator(client: client, cache: ImmichCache(client: client), container: .albums)
+        let enumerator = ItemEnumerator(client: client, cache: ImmichCache(client: client), container: .favorites)
         let anchorExp = expectation(description: "anchor")
         enumerator.currentSyncAnchor { anchor in
-            XCTAssertEqual(anchor?.rawValue, Data("anchor-v1".utf8))
+            XCTAssertNil(anchor)
             anchorExp.fulfill()
         }
         await fulfillment(of: [anchorExp], timeout: 5)

--- a/Tests/ImmichClientIntegrationTests.swift
+++ b/Tests/ImmichClientIntegrationTests.swift
@@ -59,14 +59,14 @@ final class ImmichClientIntegrationTests: IntegrationTestCase {
     func testSearchAllCityReturnsAssets() async throws {
         let places = try await client.listCities()
         let place = try XCTUnwrap(places.first)
-        let assets = try await client.searchAllCity(country: place.country, city: place.city)
+        let assets = try await client.searchAllViaPage(for: .place(country: place.country, city: place.city), size: 1000)
         XCTAssertFalse(assets.isEmpty, "the city's representative asset should be findable")
     }
 
     func testSearchAllTagReturnsAssets() async throws {
         let tags = try await client.listTags()
         for tag in tags.prefix(25) {
-            let assets = try await client.searchAllTag(tagID: tag.tagID)
+            let assets = try await client.searchAllViaPage(for: .tag(id: tag.tagID), size: 1000)
             if assets.isEmpty == false {
                 XCTAssertFalse(try XCTUnwrap(assets.first).assetID.isEmpty)
                 return

--- a/Tests/ImmichClientMockTests.swift
+++ b/Tests/ImmichClientMockTests.swift
@@ -128,7 +128,7 @@ final class ImmichClientMockTests: XCTestCase {
             let next: String = if calls.next() == 1 { "\"2\"" } else { "null" }
             return (200, Data(#"{"assets":{"items":[\#(item)],"nextPage":\#(next)}}"#.utf8))
         }
-        let assets = try await client.searchAllFavorites()
+        let assets = try await client.searchAllViaPage(for: .favorite, size: 1000)
         XCTAssertEqual(assets.count, 2, "two pages, one item each")
     }
 

--- a/project.yml
+++ b/project.yml
@@ -13,6 +13,8 @@ settings:
     CODE_SIGN_STYLE: Automatic
     PRODUCT_NAME: "$(TARGET_NAME)"
     ENABLE_HARDENED_RUNTIME: "YES"
+    DEAD_CODE_STRIPPING: "YES"
+    ENABLE_USER_SCRIPT_SANDBOXING: "YES"
 packages:
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
@@ -48,6 +50,12 @@ targets:
         SUFeedURL: https://findich.app/appcast.xml
         SUPublicEDKey: "94jQG1X0RJQd4ggp3KONMl8KhN9InckUTUeqDFLrsxs="
         SUEnableInstallerLauncherService: true
+        # Self-hosters reach Immich over plain http (LAN IP, Tailscale 100.64/10,
+        # reverse proxies without TLS). ATS blocks cleartext by default, so the
+        # connection test fails before any request leaves the machine. The app only
+        # ever contacts the single user-supplied server with the user's own key.
+        NSAppTransportSecurity:
+          NSAllowsArbitraryLoads: true
     dependencies:
       - target: ImmichDriveFileProvider
         embed: true
@@ -74,6 +82,10 @@ targets:
         CFBundleDisplayName: Findich File Provider
         CFBundleShortVersionString: "$(MARKETING_VERSION)"
         CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        # ATS is enforced per bundle, so the extension needs its own exception: it
+        # enumerates and downloads over the same plain-http server as the app.
+        NSAppTransportSecurity:
+          NSAllowsArbitraryLoads: true
         NSExtension:
           NSExtensionFileProviderDocumentGroup: QZSF4W9PK3.app.quub.immichdrive
           NSExtensionFileProviderSupportsEnumeration: true


### PR DESCRIPTION
## Summary

Make big libraries are finally usable in Finder. A huge album used to make Finder hang until the whole thing materialized. Now you can split it into sub-folders that load one at a time. The rest is smaller stuff that piled up after launch, all behind a new Options tab.

<img width="470" height="660" alt="Capture d’écran 2026-06-25 à 14 11 33" src="https://github.com/user-attachments/assets/0418272b-c11e-4368-b52a-3dd057172d87" />

## Splitting large folders
Turn on "Split large folders" in Options and pick how:
- Pages: numbered ranges, `0001-1000`, `1001-2000`, and so on.
- Year & month: Album, then Year, then Month, then pages if a single month is still too big. Levels with only one value get skipped, so a single-year album doesn't display a useless "2024" folder. The grouping reads each asset's capture date, and so does the code that figures out an asset's parent folder, so the two always match.
- Albums, people, tags, favorites and timeline months. Places and single months just use pages.

## Free up space
A button under Storage that pushes downloaded originals back to placeholders to reclaim disk (`NSFileProviderManager.evictItem`).

## Plain-HTTP servers
It now works

## Heads-up
- Everything goes through `/search/metadata`, which leaves out archived assets.
- Over `http` the API key is sent in the clear.

## Tests
Added tests for the settings/date layout, the enumeration paths, the overflow/clamp guards and updated the existing enumerator and client tests.