### PR TITLE
feat: custom request headers for servers behind an auth proxy

### DIFF
--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -268,7 +268,13 @@ struct ContentView: View {
             return
         }
 
-        customHeaders = customHeaders.filter { $0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
+        customHeaders = customHeaders.compactMap { header in
+            let name = header.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if name.isEmpty {
+                return nil
+            }
+            return CustomHeader(name: name, value: header.value.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
         let previous = CredentialStore.load()
         CredentialStore.save(baseURL: baseURL, apiKey: apiKey, customHeaders: customHeaders)
         VisibleSections.save(visibleSections)

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ContentView: View {
     @State private var baseURL = ""
     @State private var apiKey = ""
+    @State private var customHeaders: [CustomHeader] = []
     @State private var showKey = false
     @State private var visibleSections: Set<SectionKind> = Set(SectionKind.allCases)
     @State private var chunking = ChunkingSettings.default
@@ -132,6 +133,38 @@ struct ContentView: View {
             }
 
             Section {
+                ForEach($customHeaders, id: \.rowID) { $header in
+                    HStack(spacing: 8) {
+                        TextField("", text: $header.name, prompt: Text("CF-Access-Client-Id"))
+                            .textFieldStyle(.plain)
+                            .autocorrectionDisabled()
+                        Divider().frame(height: 16)
+                        SecureField("", text: $header.value, prompt: Text("Value"))
+                            .textFieldStyle(.plain)
+                            .autocorrectionDisabled()
+                        Button {
+                            customHeaders.removeAll { $0.rowID == header.rowID }
+                        } label: {
+                            Image(systemName: "minus.circle.fill")
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.secondary)
+                        .help("Remove header")
+                    }
+                }
+                Button {
+                    customHeaders.append(CustomHeader(name: "", value: ""))
+                } label: {
+                    Label("Add header", systemImage: "plus.circle.fill")
+                }
+                .buttonStyle(.borderless)
+            } header: {
+                Text("Custom request headers")
+            } footer: {
+                Text("Sent on every request, for a server behind an auth proxy. For Cloudflare Access, add CF-Access-Client-Id and CF-Access-Client-Secret from a service token.")
+            }
+
+            Section {
                 ForEach(SectionKind.allCases, id: \.self) { kind in
                     Toggle(isOn: binding(for: kind)) {
                         Label {
@@ -234,6 +267,7 @@ struct ContentView: View {
         if let credentials = CredentialStore.load() {
             baseURL = credentials.baseURL.absoluteString
             apiKey = credentials.apiKey
+            customHeaders = credentials.customHeaders
         }
         visibleSections = VisibleSections.load()
         chunking = ChunkingSettings.load()
@@ -250,18 +284,20 @@ struct ContentView: View {
         }
         let albumCount: Int
         do {
-            albumCount = try await ImmichClient(baseURL: url, apiKey: apiKey).listAlbums().count
+            albumCount = try await ImmichClient(baseURL: url, apiKey: apiKey, customHeaders: customHeaders.asRequestHeaders).listAlbums().count
         } catch {
             status = .failure("Couldn’t connect. Check the address and API key.")
             return
         }
 
         let previous = CredentialStore.load()
-        CredentialStore.save(baseURL: baseURL, apiKey: apiKey)
+        CredentialStore.save(baseURL: baseURL, apiKey: apiKey, customHeaders: customHeaders)
         VisibleSections.save(visibleSections)
         chunking = chunking.clampedToValidSize()
         ChunkingSettings.save(chunking)
-        let credentialsChanged = previous?.apiKey != apiKey || previous?.baseURL.absoluteString != baseURL
+        let credentialsChanged = previous?.apiKey != apiKey
+            || previous?.baseURL.absoluteString != baseURL
+            || previous?.customHeaders != customHeaders
         do {
             if isEnabled && credentialsChanged {
                 try await DomainManager.reload()

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -43,6 +43,7 @@ struct ContentView: View {
     private var optionsTab: some View {
         OptionsTab(
             chunking: $chunking,
+            customHeaders: $customHeaders,
             isEnabled: isEnabled,
             isFreeingSpace: isFreeingSpace,
             freedMessage: freedMessage,
@@ -130,38 +131,15 @@ struct ContentView: View {
                 } label: {
                     Label("API Key", systemImage: "key.fill")
                 }
-            }
 
-            Section {
-                ForEach($customHeaders, id: \.rowID) { $header in
-                    HStack(spacing: 8) {
-                        TextField("", text: $header.name, prompt: Text("CF-Access-Client-Id"))
-                            .textFieldStyle(.plain)
-                            .autocorrectionDisabled()
-                        Divider().frame(height: 16)
-                        SecureField("", text: $header.value, prompt: Text("Value"))
-                            .textFieldStyle(.plain)
-                            .autocorrectionDisabled()
-                        Button {
-                            customHeaders.removeAll { $0.rowID == header.rowID }
-                        } label: {
-                            Image(systemName: "minus.circle.fill")
-                        }
-                        .buttonStyle(.borderless)
-                        .foregroundStyle(.secondary)
-                        .help("Remove header")
+                HStack {
+                    Spacer()
+                    Button("Add custom headers") {
+                        selectedTab = .options
                     }
+                    .buttonStyle(.link)
+                    .font(.callout)
                 }
-                Button {
-                    customHeaders.append(CustomHeader(name: "", value: ""))
-                } label: {
-                    Label("Add header", systemImage: "plus.circle.fill")
-                }
-                .buttonStyle(.borderless)
-            } header: {
-                Text("Custom request headers")
-            } footer: {
-                Text("Sent on every request, for a server behind an auth proxy. For Cloudflare Access, add CF-Access-Client-Id and CF-Access-Client-Secret from a service token.")
             }
 
             Section {
@@ -290,6 +268,7 @@ struct ContentView: View {
             return
         }
 
+        customHeaders = customHeaders.filter { $0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false }
         let previous = CredentialStore.load()
         CredentialStore.save(baseURL: baseURL, apiKey: apiKey, customHeaders: customHeaders)
         VisibleSections.save(visibleSections)

--- a/App/OptionsTab.swift
+++ b/App/OptionsTab.swift
@@ -32,14 +32,17 @@ struct OptionsTab: View {
                     .buttonStyle(.borderless)
                     .foregroundStyle(.secondary)
                     .help("Remove header")
+                    .accessibilityLabel("Remove header")
                 } label: {
                     HStack(spacing: 8) {
                         TextField("", text: $header.name, prompt: Text("CF-Access-Client-Id"))
                             .textFieldStyle(.roundedBorder)
                             .autocorrectionDisabled()
+                            .accessibilityLabel("Header name")
                         SecureField("", text: $header.value, prompt: Text("Value"))
                             .textFieldStyle(.roundedBorder)
                             .autocorrectionDisabled()
+                            .accessibilityLabel("Header value")
                     }
                 }
             }

--- a/App/OptionsTab.swift
+++ b/App/OptionsTab.swift
@@ -5,6 +5,7 @@ import SwiftUI
 // values save alongside the rest of the settings when the domain is enabled.
 struct OptionsTab: View {
     @Binding var chunking: ChunkingSettings
+    @Binding var customHeaders: [CustomHeader]
     let isEnabled: Bool
     let isFreeingSpace: Bool
     let freedMessage: String?
@@ -13,9 +14,46 @@ struct OptionsTab: View {
     var body: some View {
         Form {
             largeFolders
+            customHeadersSection
             storage
         }
         .formStyle(.grouped)
+    }
+
+    private var customHeadersSection: some View {
+        Section {
+            ForEach($customHeaders, id: \.rowID) { $header in
+                LabeledContent {
+                    Button {
+                        customHeaders.removeAll { $0.rowID == header.rowID }
+                    } label: {
+                        Image(systemName: "minus.circle.fill")
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .help("Remove header")
+                } label: {
+                    HStack(spacing: 8) {
+                        TextField("", text: $header.name, prompt: Text("CF-Access-Client-Id"))
+                            .textFieldStyle(.roundedBorder)
+                            .autocorrectionDisabled()
+                        SecureField("", text: $header.value, prompt: Text("Value"))
+                            .textFieldStyle(.roundedBorder)
+                            .autocorrectionDisabled()
+                    }
+                }
+            }
+            Button {
+                customHeaders.append(CustomHeader(name: "", value: ""))
+            } label: {
+                Label("Add header", systemImage: "plus.circle.fill")
+            }
+            .buttonStyle(.borderless)
+        } header: {
+            Text("Custom request headers")
+        } footer: {
+            Text("Sent on every request, for a server behind an auth proxy. For Cloudflare Access, add CF-Access-Client-Id and CF-Access-Client-Secret from a service token.")
+        }
     }
 
     private var largeFolders: some View {

--- a/FileProvider/FileProviderExtension.swift
+++ b/FileProvider/FileProviderExtension.swift
@@ -284,7 +284,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     private let domain: NSFileProviderDomain
 
     required convenience init(domain: NSFileProviderDomain) {
-        let client = CredentialStore.load().map { ImmichClient(baseURL: $0.baseURL, apiKey: $0.apiKey) }
+        let client = CredentialStore.load().map { ImmichClient(baseURL: $0.baseURL, apiKey: $0.apiKey, customHeaders: $0.customHeaders.asRequestHeaders) }
         self.init(domain: domain, client: client, cache: client.map(ImmichCache.init(client:)))
         fileProviderLog.log("init, credentials present: \(client != nil, privacy: .public)")
     }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Why pay-what-you-want? Shipping a Mac app outside the App Store needs an Apple D
 
 Note: photos Immich indexes from an **external library** are read-only. Findich browses and downloads them like any other asset, but it can't write them back; Immich owns those files and refreshes them from the source itself. Findich doesn't single them out in Finder yet, so a delete or move you try there just won't take.
 
+## Servers behind an auth proxy
+
+If your Immich server sits behind an authenticating reverse proxy (Cloudflare Access, basic-auth, a WAF), add the headers it expects under **Setup → Custom request headers**; they ride along on every request, the same as Immich's own "custom proxy headers". For a Cloudflare Access service token, add `CF-Access-Client-Id` and `CF-Access-Client-Secret`. Those values can be bearer tokens, so they're stored in the Keychain alongside the API key, not in the App Group preferences.
+
 ## Requirements
 
 - macOS 13 or later
@@ -159,6 +163,7 @@ The extension's `Info.plist` **must** include `NSExtensionFileProviderDocumentGr
 - [x] `Favorites/` view: favorited assets, flat (`isFavorite`)
 - [x] Options tab: split large folders into pages or year/month groups
 - [x] Free up space: evict downloaded originals back to placeholders
+- [x] Custom request headers: reach a server behind Cloudflare Access / an auth proxy
 - [ ] Full two-way sync: pull remote changes via `enumerateChanges` + sync anchors
 
 ## Releasing

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Note: photos Immich indexes from an **external library** are read-only. Findich 
 
 ## Servers behind an auth proxy
 
-If your Immich server sits behind an authenticating reverse proxy (Cloudflare Access, basic-auth, a WAF), add the headers it expects under **Setup → Custom request headers**; they ride along on every request, the same as Immich's own "custom proxy headers". For a Cloudflare Access service token, add `CF-Access-Client-Id` and `CF-Access-Client-Secret`. Those values can be bearer tokens, so they're stored in the Keychain alongside the API key, not in the App Group preferences.
+If your Immich server sits behind an authenticating reverse proxy (Cloudflare Access, basic-auth, a WAF), add the headers it expects under **Options → Custom request headers** (a shortcut link sits in the Setup tab); they ride along on every request, the same as Immich's own "custom proxy headers". For a Cloudflare Access service token, add `CF-Access-Client-Id` and `CF-Access-Client-Secret`. Those values can be bearer tokens, so they're stored in the Keychain alongside the API key, not in the App Group preferences.
 
 ## Requirements
 

--- a/Shared/CredentialStore.swift
+++ b/Shared/CredentialStore.swift
@@ -4,15 +4,20 @@ import Security
 struct ImmichCredentials: Sendable {
     let baseURL: URL
     let apiKey: String
+    // Empty when the server is reached directly; otherwise the user's custom
+    // request headers (e.g. Cloudflare Access service-token headers).
+    let customHeaders: [CustomHeader]
 }
 
-// A tiny seam over the three Keychain operations CredentialStore needs.
-// Production uses SystemKeychain (the real Keychain); tests substitute an
-// in-memory backing so they never touch the Keychain / SecurityAgent.
+// A tiny seam over the Keychain operations CredentialStore needs, keyed by
+// account so it can hold more than one secret (the API key, and the custom
+// header set). Production uses SystemKeychain (the real Keychain); tests
+// substitute an in-memory backing so they never touch the Keychain /
+// SecurityAgent.
 protocol KeychainBacking: Sendable {
-    func save(_ apiKey: String)
-    func load() -> String?
-    func delete()
+    func save(_ value: String, account: String)
+    func load(account: String) -> String?
+    func delete(account: String)
 }
 
 // The real Keychain. Items go in the data-protection keychain so access is gated
@@ -20,41 +25,40 @@ protocol KeychainBacking: Sendable {
 // than a per-binary ACL, which would otherwise re-prompt on every signed update.
 struct SystemKeychain: KeychainBacking {
     private let keychainService = "app.quub.immichdrive"
-    private let keychainAccount = "immich-api-key"
 
     // The [String: Any] dictionaries below are the unavoidable boundary with
     // Apple's C-level Security framework. They are confined to this file.
-    private func baseQuery() -> [String: Any] {
+    private func baseQuery(account: String) -> [String: Any] {
         [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: keychainService,
-            kSecAttrAccount as String: keychainAccount,
+            kSecAttrAccount as String: account,
             kSecAttrAccessGroup as String: AppGroup.keychainAccessGroup,
             kSecUseDataProtectionKeychain as String: true
         ]
     }
 
-    // Update the item in place (delete-then-add silently kept the previous key
-    // on macOS, so an updated key never took effect); add only if absent.
-    func save(_ apiKey: String) {
-        let data = Data(apiKey.utf8)
-        // AfterFirstUnlock lets the extension read the key in the background while
-        // the screen is locked; the default (WhenUnlocked) would block that.
+    // Update the item in place (delete-then-add silently kept the previous value
+    // on macOS, so an updated secret never took effect); add only if absent.
+    func save(_ value: String, account: String) {
+        let data = Data(value.utf8)
+        // AfterFirstUnlock lets the extension read the secret in the background
+        // while the screen is locked; the default (WhenUnlocked) would block that.
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock
         ]
-        let status = SecItemUpdate(baseQuery() as CFDictionary, attributes as CFDictionary)
+        let status = SecItemUpdate(baseQuery(account: account) as CFDictionary, attributes as CFDictionary)
         if status == errSecItemNotFound {
-            var query = baseQuery()
+            var query = baseQuery(account: account)
             query[kSecValueData as String] = data
             query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
             SecItemAdd(query as CFDictionary, nil)
         }
     }
 
-    func load() -> String? {
-        var query = baseQuery()
+    func load(account: String) -> String? {
+        var query = baseQuery(account: account)
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
         var result: CFTypeRef?
@@ -65,30 +69,30 @@ struct SystemKeychain: KeychainBacking {
         return String(data: data, encoding: .utf8)
     }
 
-    func delete() {
-        SecItemDelete(baseQuery() as CFDictionary)
+    func delete(account: String) {
+        SecItemDelete(baseQuery(account: account) as CFDictionary)
     }
 }
 
 // In-memory KeychainBacking for tests. NSLock-guarded to stay Sendable under
 // Swift 6 strict concurrency, matching RequestLog in Tests/MockURLProtocol.swift.
 final class InMemoryKeychain: KeychainBacking, @unchecked Sendable {
-    private var stored: String?
+    private var stored: [String: String] = [:]
     private let lock = NSLock()
 
-    func save(_ apiKey: String) {
+    func save(_ value: String, account: String) {
         lock.lock(); defer { lock.unlock() }
-        stored = apiKey
+        stored[account] = value
     }
 
-    func load() -> String? {
+    func load(account: String) -> String? {
         lock.lock(); defer { lock.unlock() }
-        return stored
+        return stored[account]
     }
 
-    func delete() {
+    func delete(account: String) {
         lock.lock(); defer { lock.unlock() }
-        stored = nil
+        stored[account] = nil
     }
 }
 
@@ -98,30 +102,53 @@ struct CredentialStore: @unchecked Sendable {
     let keychain: KeychainBacking
     let defaults: UserDefaults?
 
-    func save(baseURL: String, apiKey: String) {
+    // Both secrets live in the Keychain (shared access group, AfterFirstUnlock),
+    // keyed by account. Header values can be bearer tokens (e.g. a Cloudflare
+    // Access client secret), so they get the same protection as the API key
+    // rather than sitting in the App Group plist.
+    static let apiKeyAccount = "immich-api-key"
+    static let customHeadersAccount = "immich-custom-headers"
+
+    func save(baseURL: String, apiKey: String, customHeaders: [CustomHeader] = []) {
         defaults?.set(baseURL, forKey: AppGroup.DefaultsKey.baseURL)
-        keychain.save(apiKey)
+        keychain.save(apiKey, account: Self.apiKeyAccount)
+        if customHeaders.isEmpty {
+            keychain.delete(account: Self.customHeadersAccount)
+        } else if let encoded = try? JSONEncoder().encode(customHeaders),
+                  let json = String(data: encoded, encoding: .utf8) {
+            keychain.save(json, account: Self.customHeadersAccount)
+        }
     }
 
     func load() -> ImmichCredentials? {
         guard let baseURLString = defaults?.string(forKey: AppGroup.DefaultsKey.baseURL),
               let baseURL = URL(string: baseURLString),
-              let apiKey = keychain.load(), apiKey.isEmpty == false else {
+              let apiKey = keychain.load(account: Self.apiKeyAccount), apiKey.isEmpty == false else {
             return nil
         }
-        return ImmichCredentials(baseURL: baseURL, apiKey: apiKey)
+        return ImmichCredentials(baseURL: baseURL, apiKey: apiKey, customHeaders: loadCustomHeaders())
+    }
+
+    private func loadCustomHeaders() -> [CustomHeader] {
+        guard let json = keychain.load(account: Self.customHeadersAccount),
+              let data = json.data(using: .utf8),
+              let headers = try? JSONDecoder().decode([CustomHeader].self, from: data) else {
+            return []
+        }
+        return headers
     }
 
     func clear() {
         defaults?.removeObject(forKey: AppGroup.DefaultsKey.baseURL)
-        keychain.delete()
+        keychain.delete(account: Self.apiKeyAccount)
+        keychain.delete(account: Self.customHeadersAccount)
     }
 
     // Static facade preserving the original call sites (App/, FileProvider/).
     static let shared = CredentialStore(keychain: SystemKeychain(), defaults: AppGroup.defaults)
 
-    static func save(baseURL: String, apiKey: String) {
-        shared.save(baseURL: baseURL, apiKey: apiKey)
+    static func save(baseURL: String, apiKey: String, customHeaders: [CustomHeader] = []) {
+        shared.save(baseURL: baseURL, apiKey: apiKey, customHeaders: customHeaders)
     }
 
     static func load() -> ImmichCredentials? {

--- a/Shared/CustomHeaders.swift
+++ b/Shared/CustomHeaders.swift
@@ -24,14 +24,22 @@ struct CustomHeader: Codable, Equatable, Sendable {
 extension Sequence where Element == CustomHeader {
     // Collapses the editable rows into the [field: value] map applied to each
     // request, dropping rows whose trimmed name is empty and trimming the
-    // surrounding whitespace a paste tends to carry. A later row with the same
-    // name wins.
+    // surrounding whitespace a paste tends to carry. HTTP header names are
+    // case-insensitive, so rows whose names differ only by case are the same
+    // header: the last-entered row wins, and its exact casing is what is sent.
     var asRequestHeaders: [String: String] {
         var headers: [String: String] = [:]
         for header in self {
             let name = header.name.trimmingCharacters(in: .whitespacesAndNewlines)
             if name.isEmpty {
                 continue
+            }
+            // Drop any prior entry that differs only by case, so the collapse is
+            // deterministic: a Dictionary's iteration order is not guaranteed, and
+            // request.setValue is itself case-insensitive, so two surviving keys
+            // would otherwise race in makeRequest.
+            for existing in headers.keys where existing.caseInsensitiveCompare(name) == .orderedSame {
+                headers[existing] = nil
             }
             headers[name] = header.value.trimmingCharacters(in: .whitespacesAndNewlines)
         }

--- a/Shared/CustomHeaders.swift
+++ b/Shared/CustomHeaders.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// One user-supplied HTTP header sent on every Immich request, so a server behind
+// an auth reverse proxy (Cloudflare Access, basic-auth, a WAF) is reachable. This
+// mirrors Immich's own "custom proxy headers". rowID is a transient SwiftUI
+// identity for the editor, deliberately neither persisted nor compared: two rows
+// are the same header when their name and value match, so a reload (which mints
+// fresh rowIDs) never reads as a credential change.
+struct CustomHeader: Codable, Equatable, Sendable {
+    let rowID = UUID()
+    var name: String
+    var value: String
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case value
+    }
+
+    static func == (lhs: CustomHeader, rhs: CustomHeader) -> Bool {
+        lhs.name == rhs.name && lhs.value == rhs.value
+    }
+}
+
+extension Sequence where Element == CustomHeader {
+    // Collapses the editable rows into the [field: value] map applied to each
+    // request, dropping rows whose trimmed name is empty and trimming the
+    // surrounding whitespace a paste tends to carry. A later row with the same
+    // name wins.
+    var asRequestHeaders: [String: String] {
+        var headers: [String: String] = [:]
+        for header in self {
+            let name = header.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if name.isEmpty {
+                continue
+            }
+            headers[name] = header.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return headers
+    }
+}

--- a/Shared/ImmichClient.swift
+++ b/Shared/ImmichClient.swift
@@ -48,15 +48,20 @@ enum AssetSearch: Sendable {
 struct ImmichClient: Sendable {
     let baseURL: URL
     let apiKey: String
+    // Extra request headers (e.g. Cloudflare Access service-token headers) sent on
+    // every call so a server behind an auth reverse proxy is reachable. Empty for
+    // a directly-reachable server.
+    let customHeaders: [String: String]
     private let session: URLSession
 
     // session is injectable so tests can drive a mocked URLProtocol; production
     // callers get the shared session.
-    init(baseURL: URL, apiKey: String, session: URLSession = .shared) {
+    init(baseURL: URL, apiKey: String, customHeaders: [String: String] = [:], session: URLSession = .shared) {
         var normalized = baseURL.absoluteString
         while normalized.hasSuffix("/") { normalized.removeLast() }
         self.baseURL = URL(string: normalized) ?? baseURL
         self.apiKey = apiKey
+        self.customHeaders = customHeaders
         self.session = session
     }
 
@@ -364,6 +369,11 @@ struct ImmichClient: Sendable {
             throw ImmichError.badURL(baseURL.absoluteString + path)
         }
         var request = URLRequest(url: url)
+        // User headers first, then x-api-key, so a header row can never shadow the
+        // real API key (the per-call Accept/Content-Type are set after this too).
+        for (field, value) in customHeaders {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         return request
     }

--- a/Shared/README.md
+++ b/Shared/README.md
@@ -2,9 +2,10 @@
 
 Code compiled into both targets, the [app](../App) and the [File Provider extension](../FileProvider), plus the test bundle. It is the contract between two separate processes, so everything here is `Sendable` and builds under the extension's Swift 6 strict concurrency.
 
-- `ImmichClient.swift`: the only thing that talks to Immich. A thin async REST client (`x-api-key` header) with paging and a bounded retry.
+- `ImmichClient.swift`: the only thing that talks to Immich. A thin async REST client (`x-api-key` plus any user custom headers) with paging and a bounded retry.
 - `ImmichModels.swift`: the `Decodable` wire models. Server `id` fields are renamed to `assetID`, `albumID`, and the like through `CodingKeys`.
-- `CredentialStore.swift`: reads and writes the server URL and API key in the Keychain, shared through the App Group.
+- `CredentialStore.swift`: reads and writes the server URL (App Group defaults) and the API key plus any custom request headers (Keychain, keyed by account), shared through the App Group.
+- `CustomHeaders.swift`: the editable name/value model for custom request headers, and its collapse into the `[field: value]` map the client sends. Used to reach a server behind an auth proxy (Cloudflare Access, basic-auth).
 - `AppGroup.swift`: the shared App Group, domain, and UserDefaults identifiers.
 - `VisibleSections.swift`: which top-level folders appear in Finder, persisted in App Group defaults.
 - `ChunkingSettings.swift`: how a large folder splits (Pages or Year & month, and the page size), persisted in App Group defaults. The page-boundary math here is shared by enumeration and an asset's parent resolution, so they cannot disagree.

--- a/Tests/CredentialStoreTests.swift
+++ b/Tests/CredentialStoreTests.swift
@@ -61,13 +61,50 @@ final class CredentialStoreTests: XCTestCase {
     func testLoadReturnsNilWhenBaseURLIsInvalid() {
         // An empty string is not a valid URL, so URL(string:) returns nil and
         // load() bails even though a key is present in the keychain.
+        store.save(baseURL: "https://immich.example.com", apiKey: "secret-key")
         defaults.set("", forKey: AppGroup.DefaultsKey.baseURL)
-        store.keychain.save("secret-key")
         XCTAssertNil(store.load())
     }
 
     func testLoadReturnsNilWhenBaseURLMissingButKeyPresent() {
-        store.keychain.save("secret-key")
+        store.save(baseURL: "https://immich.example.com", apiKey: "secret-key")
+        defaults.removeObject(forKey: AppGroup.DefaultsKey.baseURL)
         XCTAssertNil(store.load())
+    }
+
+    // MARK: custom headers
+
+    func testCustomHeadersRoundTrip() {
+        let headers = [
+            CustomHeader(name: "CF-Access-Client-Id", value: "id"),
+            CustomHeader(name: "CF-Access-Client-Secret", value: "secret")
+        ]
+        store.save(baseURL: "https://immich.example.com", apiKey: "k", customHeaders: headers)
+        XCTAssertEqual(store.load()?.customHeaders, headers)
+    }
+
+    func testNoCustomHeadersLoadsAsEmpty() {
+        store.save(baseURL: "https://immich.example.com", apiKey: "k")
+        XCTAssertEqual(store.load()?.customHeaders, [])
+    }
+
+    // Saving an empty set clears a previously-stored header item rather than
+    // leaving stale headers behind.
+    func testSavingEmptyHeadersClearsPreviousHeaders() {
+        store.save(baseURL: "https://immich.example.com", apiKey: "k", customHeaders: [CustomHeader(name: "X", value: "1")])
+        XCTAssertEqual(store.load()?.customHeaders.count, 1)
+
+        store.save(baseURL: "https://immich.example.com", apiKey: "k", customHeaders: [])
+        XCTAssertEqual(store.load()?.customHeaders, [])
+    }
+
+    // clear() must remove the header item too, so a later save with no headers
+    // doesn't resurrect the old ones.
+    func testClearRemovesCustomHeaders() {
+        store.save(baseURL: "https://immich.example.com", apiKey: "k", customHeaders: [CustomHeader(name: "X", value: "1")])
+        store.clear()
+
+        store.save(baseURL: "https://immich.example.com", apiKey: "k")
+        XCTAssertEqual(store.load()?.customHeaders, [])
     }
 }

--- a/Tests/CustomHeaderTests.swift
+++ b/Tests/CustomHeaderTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+final class CustomHeaderTests: XCTestCase {
+    func testAsRequestHeadersDropsEmptyNames() {
+        let headers = [
+            CustomHeader(name: "   ", value: "ignored"),
+            CustomHeader(name: "X-Real", value: "1")
+        ]
+        XCTAssertEqual(headers.asRequestHeaders, ["X-Real": "1"])
+    }
+
+    func testAsRequestHeadersTrimsWhitespace() {
+        let headers = [CustomHeader(name: "  CF-Access-Client-Id ", value: " tok\n")]
+        XCTAssertEqual(headers.asRequestHeaders, ["CF-Access-Client-Id": "tok"])
+    }
+
+    func testAsRequestHeadersLaterDuplicateWins() {
+        let headers = [CustomHeader(name: "X", value: "first"), CustomHeader(name: "X", value: "second")]
+        XCTAssertEqual(headers.asRequestHeaders, ["X": "second"])
+    }
+
+    // Two rows with identical name/value are equal despite distinct rowIDs, so a
+    // reload (which mints fresh rowIDs) never reads as a credential change.
+    func testEqualityIgnoresRowIdentity() {
+        XCTAssertEqual(CustomHeader(name: "X", value: "1"), CustomHeader(name: "X", value: "1"))
+    }
+}

--- a/Tests/CustomHeaderTests.swift
+++ b/Tests/CustomHeaderTests.swift
@@ -19,6 +19,14 @@ final class CustomHeaderTests: XCTestCase {
         XCTAssertEqual(headers.asRequestHeaders, ["X": "second"])
     }
 
+    // HTTP header names are case-insensitive, so rows differing only by case
+    // collapse to one entry deterministically: the last-entered row wins and
+    // keeps its own casing.
+    func testAsRequestHeadersDedupesCaseInsensitively() {
+        let headers = [CustomHeader(name: "X-Foo", value: "first"), CustomHeader(name: "x-foo", value: "second")]
+        XCTAssertEqual(headers.asRequestHeaders, ["x-foo": "second"])
+    }
+
     // Two rows with identical name/value are equal despite distinct rowIDs, so a
     // reload (which mints fresh rowIDs) never reads as a credential change.
     func testEqualityIgnoresRowIdentity() {

--- a/Tests/ImmichClientMockTests.swift
+++ b/Tests/ImmichClientMockTests.swift
@@ -183,20 +183,32 @@ final class ImmichClientMockTests: XCTestCase {
     // every outgoing request, which is what lets a server behind an auth proxy be
     // reached at all.
     func testCustomHeadersAreSentOnEveryRequest() async throws {
-        let seen = HeaderCapture()
+        let log = RequestLog()
+        let client = headerCapturingClient(customHeaders: ["CF-Access-Client-Id": "tok"], log: log)
+        _ = try await client.listAlbums()
+        XCTAssertEqual(log.requests.first?.value(forHTTPHeaderField: "CF-Access-Client-Id"), "tok")
+    }
+
+    // A header row named like the API-key header cannot shadow the real key: the
+    // real x-api-key is set after the custom headers, so it always wins.
+    func testCustomHeaderCannotShadowAPIKey() async throws {
+        let log = RequestLog()
+        let client = headerCapturingClient(apiKey: "real-key", customHeaders: ["x-api-key": "evil"], log: log)
+        _ = try await client.listAlbums()
+        XCTAssertEqual(log.requests.first?.value(forHTTPHeaderField: "x-api-key"), "real-key")
+    }
+
+    // An ImmichClient whose requests are recorded into `log`, so a test can assert
+    // on the headers that actually went out.
+    private func headerCapturingClient(apiKey: String = "k", customHeaders: [String: String], log: RequestLog) -> ImmichClient {
         MockURLProtocol.handler = { request in
-            seen.record(request.value(forHTTPHeaderField: "CF-Access-Client-Id"))
+            log.record(request)
             return (200, Data("[]".utf8))
         }
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
         let session = URLSession(configuration: config)
-        let client = ImmichClient(
-            baseURL: URL(string: "https://mock.test")!, apiKey: "k",
-            customHeaders: ["CF-Access-Client-Id": "tok"], session: session
-        )
-        _ = try await client.listAlbums()
-        XCTAssertEqual(seen.value, "tok")
+        return ImmichClient(baseURL: URL(string: "https://mock.test")!, apiKey: apiKey, customHeaders: customHeaders, session: session)
     }
 
     func testDownloadReturnsRawBytes() async throws {
@@ -241,21 +253,6 @@ final class ImmichClientMockTests: XCTestCase {
     func testNonEmptyYearsThrowsOnError() async {
         let client = MockClient.make { _ in (500, Data("{}".utf8)) }
         await XCTAssertThrowsErrorAsync(try await client.nonEmptyYears())
-    }
-}
-
-// Captures a single header value seen by the mock handler, lock-guarded so it
-// stays Sendable under Swift 6 strict concurrency.
-final class HeaderCapture: @unchecked Sendable {
-    private var stored: String?
-    private let lock = NSLock()
-    func record(_ value: String?) {
-        lock.lock(); defer { lock.unlock() }
-        stored = value
-    }
-    var value: String? {
-        lock.lock(); defer { lock.unlock() }
-        return stored
     }
 }
 

--- a/Tests/ImmichClientMockTests.swift
+++ b/Tests/ImmichClientMockTests.swift
@@ -179,6 +179,26 @@ final class ImmichClientMockTests: XCTestCase {
         XCTAssertEqual(client.baseURL.absoluteString, "https://mock.test")
     }
 
+    // Custom headers (e.g. a Cloudflare Access service token) are attached to
+    // every outgoing request, which is what lets a server behind an auth proxy be
+    // reached at all.
+    func testCustomHeadersAreSentOnEveryRequest() async throws {
+        let seen = HeaderCapture()
+        MockURLProtocol.handler = { request in
+            seen.record(request.value(forHTTPHeaderField: "CF-Access-Client-Id"))
+            return (200, Data("[]".utf8))
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let client = ImmichClient(
+            baseURL: URL(string: "https://mock.test")!, apiKey: "k",
+            customHeaders: ["CF-Access-Client-Id": "tok"], session: session
+        )
+        _ = try await client.listAlbums()
+        XCTAssertEqual(seen.value, "tok")
+    }
+
     func testDownloadReturnsRawBytes() async throws {
         let client = MockClient.make { _ in (200, Data([0xFF, 0xD8, 0xFF])) }
         let original = try await client.downloadOriginal(assetID: "x")
@@ -221,6 +241,21 @@ final class ImmichClientMockTests: XCTestCase {
     func testNonEmptyYearsThrowsOnError() async {
         let client = MockClient.make { _ in (500, Data("{}".utf8)) }
         await XCTAssertThrowsErrorAsync(try await client.nonEmptyYears())
+    }
+}
+
+// Captures a single header value seen by the mock handler, lock-guarded so it
+// stays Sendable under Swift 6 strict concurrency.
+final class HeaderCapture: @unchecked Sendable {
+    private var stored: String?
+    private let lock = NSLock()
+    func record(_ value: String?) {
+        lock.lock(); defer { lock.unlock() }
+        stored = value
+    }
+    var value: String? {
+        lock.lock(); defer { lock.unlock() }
+        return stored
     }
 }
 

--- a/Tests/MockURLProtocol.swift
+++ b/Tests/MockURLProtocol.swift
@@ -29,16 +29,19 @@ final class MockURLProtocol: URLProtocol {
     }
 }
 
-// Records "METHOD path" for each intercepted request so tests can assert which
-// endpoints were actually hit.
+// Records each intercepted request: a "METHOD path" string so tests can assert
+// which endpoints were hit, and the request itself for header/body assertions.
 final class RequestLog: @unchecked Sendable {
     private var entries: [String] = []
+    private var captured: [URLRequest] = []
     private let lock = NSLock()
     func record(_ request: URLRequest) {
         lock.lock(); defer { lock.unlock() }
         entries.append("\(request.httpMethod ?? "?") \(request.url?.path ?? "?")")
+        captured.append(request)
     }
     var all: [String] { lock.lock(); defer { lock.unlock() }; return entries }
+    var requests: [URLRequest] { lock.lock(); defer { lock.unlock() }; return captured }
     func contains(_ entry: String) -> Bool { all.contains(entry) }
 }
 


### PR DESCRIPTION
## What

User-editable **custom request headers** so an Immich server behind an authenticating reverse proxy — Cloudflare Access, basic-auth, a WAF — is reachable. Mirrors Immich's own "custom proxy headers".

## Why

Some self-hosters expose Immich through Cloudflare Zero Trust and authenticate machine clients with a service token sent as `CF-Access-Client-Id` / `CF-Access-Client-Secret` headers. Without a way to attach those, every request is bounced before it reaches Immich.

## How

- `CustomHeader {name, value}` model; `asRequestHeaders` collapses the editable rows into the `[field: value]` map sent on the wire (trims, drops empty names, last-duplicate-wins) — one boundary between the UI/storage shape and the request shape.
- Applied in `ImmichClient.makeRequest`, the single chokepoint every request flows through (enumeration, thumbnails, originals, uploads), **before** `x-api-key` so a header row can never shadow the real key.
- Persisted in the **Keychain** (the seam is now account-keyed), not the App Group plist — header values can be bearer tokens.
- Edited under **Options → Custom request headers**, with a shortcut link from the Setup tab. Passed to the File Provider extension so background enumeration reaches the same proxied server.

## Testing

- Unit tests: header collapse (trim / empty / duplicate), Keychain round-trip + clear, headers sent on every request, and that an `x-api-key` row cannot shadow the real key.
- All tests pass; app + extension build.

## Docs

README "Servers behind an auth proxy" section + `Shared/README` manifest updated.
