### PR TITLE
chore(release): auto-publish the appcast and bump the Homebrew cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,17 @@ Then build, notarize, staple, and package a DMG:
 
 ```bash
 ./scripts/release.sh            # build build/Findich.dmg
-./scripts/release.sh 1.0.0      # ...and also publish it as a GitHub Release
+./scripts/release.sh 1.0.0      # ...and publish: GitHub Release, appcast, Homebrew cask
 ```
 
-The stapled `build/Findich.dmg` is the artifact to distribute: upload it to Gumroad, or pass a version to publish it on GitHub Releases too.
+The stapled `build/Findich.dmg` is the artifact to distribute: upload it to Gumroad, or pass a version to do the rest. With a version, the script also creates the GitHub Release, commits and pushes `site/public/appcast.xml`, and bumps the Homebrew cask (version + sha256) in the tap, committing and pushing it. The tap is a sibling `../homebrew-tap` clone by default; set `TAP_DIR` if yours is elsewhere.
 
 ### Smoke test before publishing
 
 Some behavior (the real Keychain, Sparkle, the Finder extension) needs a signed run and is not covered by the unit tests. Run this once per release, with version N already installed:
 
-1. `./scripts/release.sh N+1` to build, notarize, publish, and sign the appcast.
-2. Commit and push `site/public/appcast.xml`, then wait for the site to deploy.
+1. `./scripts/release.sh N+1` — builds, notarizes, publishes the GitHub Release, pushes the appcast, and bumps the Homebrew cask.
+2. Wait for the site to deploy so the appcast is live.
 3. In version N: Findich menu → Check for Updates, which should offer N+1.
 4. Download it and confirm it installs and relaunches (the EdDSA signature verifies).
 5. Keychain: no keychain prompt during or after the update.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -75,5 +75,33 @@ $CHANGELOG"
     SIG_AND_LEN=$("$SIGN_UPDATE" "$DMG")
     DMG_URL="https://github.com/Majorfi/immich-in-finder/releases/download/v$VERSION/$APP_NAME.dmg"
     python3 scripts/update_appcast.py site/public/appcast.xml "$VERSION" "$DMG_URL" "$SIG_AND_LEN" "$CHANGELOG"
-    echo "Updated site/public/appcast.xml. Commit and push site/ to publish the update."
+
+    # Publish the appcast so installed copies can auto-update; it is served from
+    # findich.app/appcast.xml, so committing and pushing site/ deploys it.
+    if ! git diff --quiet -- site/public/appcast.xml; then
+        git add site/public/appcast.xml
+        git commit -m "chore(site): publish $VERSION appcast"
+        git push
+        echo "Committed and pushed the appcast."
+    fi
+
+    # Bump the Homebrew cask with the sha of the DMG we just built and uploaded
+    # (same artifact, no re-download). TAP_DIR defaults to a sibling clone of the
+    # tap repo; override it if yours lives elsewhere. Skipped if the cask is absent.
+    REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+    TAP_DIR="${TAP_DIR:-$REPO_ROOT/../homebrew-tap}"
+    CASK="$TAP_DIR/Casks/$(echo "$APP_NAME" | tr '[:upper:]' '[:lower:]').rb"
+    if [ -f "$CASK" ]; then
+        SHA=$(shasum -a 256 "$DMG" | awk '{print $1}')
+        sed -i '' -E "s/version \"[^\"]+\"/version \"$VERSION\"/; s/sha256 \"[^\"]+\"/sha256 \"$SHA\"/" "$CASK"
+        if git -C "$TAP_DIR" diff --quiet -- "$CASK"; then
+            echo "Cask already at $VERSION; nothing to push."
+        else
+            git -C "$TAP_DIR" commit -m "findich $VERSION" -- "$CASK"
+            git -C "$TAP_DIR" push
+            echo "Bumped and pushed the Homebrew cask ($VERSION)."
+        fi
+    else
+        echo "Cask not found at $CASK; skipping the Homebrew bump (set TAP_DIR?)." >&2
+    fi
 fi


### PR DESCRIPTION
## What

`release.sh`, when passed a version, now finishes the whole release instead of stopping at "write the appcast, then commit it yourself":

- commits and pushes `site/public/appcast.xml` (so the Sparkle auto-update goes live), and
- bumps the Homebrew cask (`version` + `sha256`) in the tap, then commits and pushes it.

A single `./scripts/release.sh <version>` now does **GitHub Release + appcast + Homebrew** in one shot.

## Why

`main`'s `release.sh` left the appcast push and the entire Homebrew bump as manual steps — which is exactly why the cask sat at 1.3.0 while 1.4.0 was already on GitHub. The cask bump uses the sha of the DMG the script **just built and uploaded** (same artifact, no re-download), so the checksum always matches the release asset.

## Details

- `TAP_DIR` defaults to a sibling `../homebrew-tap` clone; override it if yours lives elsewhere.
- The cask bump is skipped cleanly (with a warning) if the cask file isn't found, so the script never hard-fails on it.
- README "Releasing" section updated to match.

This supersedes the older `chore/automate-release` branch, which carried the same idea but was based on a pre-1.4.0 `main` and now conflicts on `release.sh`; it can be closed/deleted once this lands.
